### PR TITLE
chore: change contract layout as per style guide

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-@sachushaji @barathcj @Phani024 @sarthak96
+* @sachushaji @barathcj @Phani024 @sarthak96
 .github @BitGo/production

--- a/contracts/Blacklistable.sol
+++ b/contracts/Blacklistable.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefau
 /**
  * @title Blacklistable
  * @dev Contract that allows blacklisting of accounts.
+ *  We are using the last bit of the balance to store the blacklist state.
  */
 contract Blacklistable is
     AccessControlDefaultAdminRulesUpgradeable,
@@ -17,18 +18,9 @@ contract Blacklistable is
     event Unblacklisted(address indexed account);
 
     // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ERC20")) - 1)) & ~bytes32(uint256(0xff))
+    // From OpenZeppelin Contracts
     bytes32 private constant ERC20StorageLocation =
         0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace00;
-
-    /**
-     * @dev Retrieves the storage location of the ERC20 contract.
-     * @return $ The storage location of the ERC20 contract.
-     */
-    function getERC20Storage() private pure returns (ERC20Storage storage $) {
-        assembly {
-            $.slot := ERC20StorageLocation
-        }
-    }
 
     /**
      * @dev Checks if an account is blacklisted.
@@ -38,22 +30,6 @@ contract Blacklistable is
     function isBlacklisted(address account) public view returns (bool) {
         ERC20Storage storage $ = getERC20Storage();
         return ($._balances[account] >> 255) == 1;
-    }
-
-    /**
-     * @dev Sets the blacklist state of an account.
-     * @param account The address to set the blacklist state for.
-     * @param state The blacklist state to set.
-     */
-    function _setBlacklistState(address account, bool state) internal {
-        ERC20Storage storage $ = getERC20Storage();
-        if (state) {
-            $._balances[account] = $._balances[account] | (1 << 255);
-            emit Blacklisted(account);
-        } else {
-            $._balances[account] = $._balances[account] & ((1 << 255) - 1);
-            emit Unblacklisted(account);
-        }
     }
 
     /**
@@ -86,6 +62,22 @@ contract Blacklistable is
     ) public view virtual override returns (uint256) {
         ERC20Storage storage $ = getERC20Storage();
         return $._balances[account] & ((1 << 255) - 1);
+    }
+
+    /**
+     * @dev Sets the blacklist state of an account.
+     * @param account The address to set the blacklist state for.
+     * @param state The blacklist state to set.
+     */
+    function _setBlacklistState(address account, bool state) internal {
+        ERC20Storage storage $ = getERC20Storage();
+        if (state) {
+            $._balances[account] = $._balances[account] | (1 << 255);
+            emit Blacklisted(account);
+        } else {
+            $._balances[account] = $._balances[account] & ((1 << 255) - 1);
+            emit Unblacklisted(account);
+        }
     }
 
     /**
@@ -129,5 +121,15 @@ contract Blacklistable is
         }
 
         emit Transfer(from, to, value);
+    }
+
+    /**
+     * @dev Retrieves the storage location of the ERC20 contract.
+     * @return $ The storage location of the ERC20 contract.
+     */
+    function getERC20Storage() private pure returns (ERC20Storage storage $) {
+        assembly {
+            $.slot := ERC20StorageLocation
+        }
     }
 }

--- a/contracts/USDS.sol
+++ b/contracts/USDS.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {ERC20PausableUpgradeable} 
-    from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PausableUpgradeable.sol";
-import {ERC20PermitUpgradeable} 
-    from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+import {ERC20PausableUpgradeable} from 
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PausableUpgradeable.sol";
+import {ERC20PermitUpgradeable} from 
+    "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 import "./Blacklistable.sol";
 
 /// @title Offcial USDS ERC-20 Implementation
@@ -77,19 +77,6 @@ contract USDS is
     }
 
     /**
-     * @dev Returns the number of decimals used by the token.
-     */
-    function decimals()
-        public
-        view
-        virtual
-        override(ERC20Upgradeable)
-        returns (uint8)
-    {
-        return 6;
-    }
-
-    /**
      * @dev Pauses all token transfers.
      */
     function pause() public onlyRole(FREEZER_ROLE) {
@@ -123,15 +110,6 @@ contract USDS is
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         reserveAddresses[oldAddress] = false;
         emit ReserveAddressRemoved(oldAddress);
-    }
-
-    /**
-     * @dev Checks if an address is a reserve address.
-     * @param account The address to be checked.
-     * @return A boolean indicating whether the address is a reserve address or not.
-     */
-    function isReserveAddress(address account) public view returns (bool) {
-        return reserveAddresses[account];
     }
 
     /**
@@ -235,30 +213,25 @@ contract USDS is
     }
 
     /**
-     * @dev Authorizes the upgrade to a new implementation contract.
-     * @param newImplementation The address of the new implementation contract.
+     * @dev Returns the number of decimals used by the token.
      */
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal override onlyRole(UPGRADER_ROLE) {}
-
-    // The following functions are overrides required by Solidity.
+    function decimals()
+        public
+        view
+        virtual
+        override(ERC20Upgradeable)
+        returns (uint8)
+    {
+        return 6;
+    }
 
     /**
-     * @dev Updates the balance of the specified addresses and emits the corresponding events.
-     * @param from The address from which tokens are transferred.
-     * @param to The address to which tokens are transferred.
-     * @param value The amount of tokens transferred.
+     * @dev Checks if an address is a reserve address.
+     * @param account The address to be checked.
+     * @return A boolean indicating whether the address is a reserve address or not.
      */
-    function _update(
-        address from,
-        address to,
-        uint256 value
-    )
-        internal
-        override(Blacklistable, ERC20Upgradeable, ERC20PausableUpgradeable)
-    {
-        ERC20PausableUpgradeable._update(from, to, value);
+    function isReserveAddress(address account) public view returns (bool) {
+        return reserveAddresses[account];
     }
 
     /**
@@ -276,5 +249,30 @@ contract USDS is
         returns (uint256)
     {
         return Blacklistable.balanceOf(account);
+    }
+
+    /**
+     * @dev Authorizes the upgrade to a new implementation contract.
+     * @param newImplementation The address of the new implementation contract.
+     */
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyRole(UPGRADER_ROLE) {}
+
+    /**
+     * @dev Updates the balance of the specified addresses and emits the corresponding events.
+     * @param from The address from which tokens are transferred.
+     * @param to The address to which tokens are transferred.
+     * @param value The amount of tokens transferred.
+     */
+    function _update(
+        address from,
+        address to,
+        uint256 value
+    )
+        internal
+        override(Blacklistable, ERC20Upgradeable, ERC20PausableUpgradeable)
+    {
+        ERC20PausableUpgradeable._update(from, to, value);
     }
 }

--- a/contracts/USDS.sol
+++ b/contracts/USDS.sol
@@ -26,7 +26,7 @@ contract USDS is
     bytes32 public constant SUPPLY_CONTROLLER_ROLE =
         keccak256("SUPPLY_CONTROLLER_ROLE");
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
-    bytes32 public constant WITHDRAWER_ROLE = keccak256("WITHDRAWER_ROLE");
+    bytes32 public constant RESCUER_ROLE = keccak256("RESCUER_ROLE");
 
     mapping(address => bool) public reserveAddresses;
 
@@ -47,7 +47,7 @@ contract USDS is
      * @param supplyController The address of the supply controller role.
      * @param upgrader The address of the upgrader role.
      * @param blacklister The address of the blacklister role.
-     * @param withdrawer The address of the withdrawer role.
+     * @param resuer The address of the resuer role.
      * @param _reserveAddresses An array of reserve addresses.
      */
     function initialize(
@@ -56,7 +56,7 @@ contract USDS is
         address supplyController,
         address upgrader,
         address blacklister,
-        address withdrawer,
+        address resuer,
         address[] memory _reserveAddresses
     ) public initializer {
         __ERC20_init("USDS", "USDS");
@@ -69,7 +69,7 @@ contract USDS is
         _grantRole(FREEZER_ROLE, freezer);
         _grantRole(SUPPLY_CONTROLLER_ROLE, supplyController);
         _grantRole(UPGRADER_ROLE, upgrader);
-        _grantRole(WITHDRAWER_ROLE, withdrawer);
+        _grantRole(RESCUER_ROLE, resuer);
         for (uint256 i = 0; i < _reserveAddresses.length; i++) {
             reserveAddresses[_reserveAddresses[i]] = true;
             emit ReserveAddressAdded(_reserveAddresses[i]);
@@ -203,11 +203,11 @@ contract USDS is
      * @param recipient The address to which the tokens will be transferred.
      * @param amount The amount of tokens to be withdrawn.
      */
-    function withdraw(
+    function rescueTokens(
         IERC20 token,
         address recipient,
         uint256 amount
-    ) public onlyRole(WITHDRAWER_ROLE) {
+    ) public onlyRole(RESCUER_ROLE) {
         require(!isBlacklisted(recipient), "Recipient is blacklisted");
         token.safeTransfer(recipient, amount);
     }

--- a/test/supply.ts
+++ b/test/supply.ts
@@ -13,7 +13,7 @@ describe("USDS Minting and Burning", function () {
   let reserve2: SignerWithAddress;
   let reserve3: SignerWithAddress;
   let blacklister: SignerWithAddress;
-  let withdrawer: SignerWithAddress
+  let rescuer: SignerWithAddress
   let recoverAddress: SignerWithAddress;
   let randomAddress: SignerWithAddress;
 
@@ -27,7 +27,7 @@ describe("USDS Minting and Burning", function () {
       reserve1,
       reserve2,
       reserve3,
-      withdrawer,
+      rescuer,
       recoverAddress,
       randomAddress
     ] = await ethers.getSigners();
@@ -40,7 +40,7 @@ describe("USDS Minting and Burning", function () {
         supplyController.address,
         upgrader.address,
         blacklister.address,
-        withdrawer.address,
+        rescuer.address,
         [reserve1.address, reserve2.address, reserve3.address],
       ],
       { kind: "uups" }
@@ -71,7 +71,7 @@ describe("USDS Minting and Burning", function () {
     expect(await contractInstance.totalSupply()).to.equal(mintAmount);
   });
 
-  it("Should be able to recover missend address", async function () {
+  it("Should be able to recover tokens stuck in contract address", async function () {
     const transferAmount = ethers.parseUnits("1000", 18);
     await contractInstance.connect(supplyController).mint(reserve3.address, transferAmount);
     const balanceAfterTransfer = await contractInstance.balanceOf(reserve3.address);
@@ -84,7 +84,7 @@ describe("USDS Minting and Burning", function () {
     expect(balance).to.equal(transferAmount);
  
     // Recover the tokens
-    await contractInstance.connect(withdrawer).withdraw(contractInstance.getAddress(), recoverAddress.address, transferAmount);
+    await contractInstance.connect(rescuer).rescueTokens(contractInstance.getAddress(), recoverAddress.address, transferAmount);
     const newTokenContractBalance = await contractInstance.balanceOf(contractInstance.getAddress());
     expect(newTokenContractBalance).to.equal( ethers.parseUnits("0", 18));
     const balanceAtRecoverAddress = await contractInstance.balanceOf(recoverAddress.address);


### PR DESCRIPTION
This change has three commits
1. https://github.com/BitGo/GoUSD/commit/5e083d105edfe55d9357daf113a43b840b8990d6 makes changes in contract as per the style guide
2. https://github.com/BitGo/GoUSD/commit/51c3865fc2ffe5cd78ff7c0f2c3716aa39e6ed6d rename erc-20 token rescuer to a more meaningful name
3. https://github.com/BitGo/GoUSD/pull/19/commits/4641896131e2c4f7365fbc97def5ca39713c0c4a fixes the code owners file to recognise global owners