### PR TITLE
chore: supply controller should destroy funds

### DIFF
--- a/contracts/USDS.sol
+++ b/contracts/USDS.sol
@@ -190,7 +190,7 @@ contract USDS is
      */
     function destroyBlacklistedFunds(
         address account
-    ) public onlyRole(BLACKLISTER_ROLE) {
+    ) public onlyRole(SUPPLY_CONTROLLER_ROLE) {
         require(isBlacklisted(account), "Address is not blacklisted");
         uint256 balance = balanceOf(account);
         _burn(account, balance);

--- a/test/blacklist.ts
+++ b/test/blacklist.ts
@@ -122,14 +122,14 @@ describe("USDS blacklist", function () {
     expect(receiverBalance).to.equal(750);
   });
 
-  it("Should allow blacklist role to destroy blacklisted funds", async function () {
+  it("Should allow supply controller role to destroy blacklisted funds", async function () {
     // Blacklist receiver
     await contractInstance.connect(blacklister).blacklist(targetAccount.address);
     const targetBalance = await contractInstance.balanceOf(targetAccount.address);
     expect(targetBalance).to.equal(750);
     
     // Destroy blacklisted funds
-    await contractInstance.connect(blacklister).destroyBlacklistedFunds(targetAccount.address);
+    await contractInstance.connect(supplyController).destroyBlacklistedFunds(targetAccount.address);
     const targetBalanceAfter = await contractInstance.balanceOf(targetAccount.address);
     expect(targetBalanceAfter).to.equal(0);
   });


### PR DESCRIPTION
this changes changes the permission of
destroying the blacklisted funds from
blacklister to supply controller

Ticket: WIN-3554