### PR TITLE
feat: reserve decimal should have min token precision

### DIFF
--- a/contracts/USDS.sol
+++ b/contracts/USDS.sol
@@ -309,13 +309,14 @@ contract USDS is
      * @dev Retrieves the latest reserve value from the proofOfReserveFeed.
      * @return reserve The latest reserve value as a uint256.
      * @return updatedAt The timestamp of the latest reserve value.
+     * @return decimalPrecision The number of decimals used by the feed.
      */
     function getLatestReserve()
         public
         view
-        returns (uint256 reserve, uint256 updatedAt)
+        returns (uint256 reserve, uint256 updatedAt, uint8 decimalPrecision)
     {
-        (reserve, updatedAt) = getLatestReserveFromFeed(proofOfReserveFeed);
+        (reserve, updatedAt, decimalPrecision) = getLatestReserveFromFeed(proofOfReserveFeed);
     }
 
     /**
@@ -346,7 +347,7 @@ contract USDS is
         uint256 mintAmount,
         bool isBatch
     ) internal view {
-        (uint256 reserves, uint256 reserveUpdateAt) = getLatestReserveFromFeed(
+        (uint256 reserves, uint256 reserveUpdateAt, uint8 reserveDecimals) = getLatestReserveFromFeed(
             feed
         );
         require(reserves > 0, "Invalid PoR data");
@@ -362,18 +363,14 @@ contract USDS is
         // different than the token's decimals
         uint256 currentSupply = totalSupply();
         uint8 trueDecimals = decimals();
-        uint8 reserveDecimals = feed.decimals();
-        require(reserveDecimals <= 18, "Invalid decimals");
+        require(reserveDecimals >= trueDecimals && reserveDecimals <= 18, "Invalid decimals");
         if (trueDecimals < reserveDecimals) {
             currentSupply =
                 currentSupply *
                 10**uint256(reserveDecimals - trueDecimals);
             mintAmount = mintAmount * 
                 10**uint256(reserveDecimals - trueDecimals);
-        } else if (trueDecimals > reserveDecimals) {
-            reserves = reserves * 10**uint256(trueDecimals - reserveDecimals);
         }
-
         // For batched minting, the mint operation is performed before validation.
         // As a result, the minted amount is already included in `totalSupply` at this point.
         // Therefore, in batch mode (`isBatch`), we only need to verify that `totalSupply`
@@ -393,10 +390,11 @@ contract USDS is
      * @param feed The address of the proofOfReserveFeed contract.
      * @return reserve The latest reserve value as a uint256.
      * @return updatedAt The timestamp of the latest reserve value.
+     * @return feedDecimals The number of decimals used by the feed.
      */
     function getLatestReserveFromFeed(
         AggregatorV3Interface feed
-    ) internal view returns (uint256 reserve, uint256 updatedAt) {
+    ) internal view returns (uint256 reserve, uint256 updatedAt, uint8 feedDecimals) {
         (
             /* uint80 roundID */,
             int reserveFunds,
@@ -407,6 +405,7 @@ contract USDS is
 
         reserve = uint256(reserveFunds);
         updatedAt = roundTimeStamp;
+        feedDecimals = feed.decimals();
     }
 
     /**

--- a/test/supply.ts
+++ b/test/supply.ts
@@ -343,34 +343,6 @@ describe("USDS Minting,  Burning And Token Rescue", function () {
      .withArgs(randomAddress.address, mintAmount);
   });
   
-  it("Should handle decimal normalization correctly when PoR decimals are lower than token decimals", async function() {
-    const mintAmount = ethers.parseUnits("1000", 6); // Token has 6 decimals
-    const totalSupply = await contractInstance.totalSupply();
-  
-    // Deploy new PoR feed with 3 decimals (lower than token's 6 decimals) 
-    const newPoRFeed = await ethers.getContractFactory("DummyAggregatorV3");
-    const newPoRFeedContract = await newPoRFeed.deploy(3, "Low decimal PoR", 1);
-  
-    // Set reserve amount in 3 decimals (need to scale up reserves)
-    const reserveAmount = (totalSupply + mintAmount) / BigInt(10**3);
-  
-    await newPoRFeedContract
-      .connect(supplyController)
-      .updateData(reserveAmount, 1, timeStampInSeconds, 1);
-      
-    await contractInstance
-      .connect(defaultAdmin)
-      .setProofOfReserveFeed(newPoRFeedContract.getAddress());
-  
-    // Mint should succeed since reserves are properly scaled
-    await expect(
-      contractInstance
-        .connect(supplyController) 
-        .mint(randomAddress.address, mintAmount)
-    ).to.emit(contractInstance, "Mint")
-     .withArgs(randomAddress.address, mintAmount);
-  });
-  
   it("Should fail mint when reserves are insufficient after decimal normalization", async function() {
     const mintAmount = ethers.parseUnits("1000", 6); // Token has 6 decimals
     const totalSupply = await contractInstance.totalSupply();
@@ -485,10 +457,12 @@ describe("USDS Minting,  Burning And Token Rescue", function () {
     await newProofFeedContract
       .connect(supplyController)
       .updateData(totalSupply, 1, timeStampInSeconds, 1);
-    const [proofFeedData] = await contractInstance
+    const [proofFeedData , updatedAt, decimals] = await contractInstance
       .connect(defaultAdmin)
       .getLatestReserve();
     expect(proofFeedData).to.equal(totalSupply);
+    expect(updatedAt).to.equal(timeStampInSeconds);
+    expect(decimals).to.equal(6);
 
     // Should error out if proof of address set to zero address
     let failed = false;
@@ -517,7 +491,7 @@ describe("USDS Minting,  Burning And Token Rescue", function () {
       .withArgs(dummyAggregatorInstance.getAddress());
   });
 
-  it("Should not allow setting PoR feed with decimals greater than 18", async function() {
+  it("Should not allow setting PoR feed with decimals > 18 or  < 6", async function() {
     const newProofFeed = await ethers.getContractFactory("DummyAggregatorV3");
     const newPoRFeedContract = await newProofFeed.deploy(
       19, // 19 decimals (greater than 18)
@@ -538,6 +512,23 @@ describe("USDS Minting,  Burning And Token Rescue", function () {
         .connect(defaultAdmin)
         .setProofOfReserveFeed(newPoRFeedAddress)
     ).to.be.revertedWith("Invalid decimals");
+
+    const newPoRFeedContractWithLessPrecision = await newProofFeed.deploy(
+      5, 
+      "Invalid decimal PoR feed",
+      1
+    );
+    const porFeedWithLessPrecision = await newPoRFeedContractWithLessPrecision.getAddress();
+    await newPoRFeedContractWithLessPrecision
+    .connect(supplyController)
+    .updateData(totalSupply, 1, timeStampInSeconds, 1);
+
+    await expect(
+      contractInstance
+        .connect(defaultAdmin)
+        .setProofOfReserveFeed(porFeedWithLessPrecision)
+    ).to.be.revertedWith("Invalid decimals");
+
   
     // Verify that feed was not updated
     const currentFeed = await contractInstance.getProofOfReserveFeed();


### PR DESCRIPTION
This change enforces token decimals to have min
precision enforced from the reserves. Also
exposes reserve precision in the public
getter function


Ticket: USDS-86