### PR TITLE
chore: add claude code github action workflow

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -1,0 +1,20 @@
+---
+name: claude-code
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  claude-code:
+    name: Invoke Claude Code AI assistant
+    uses: BitGo/github-ai-assistant/.github/workflows/claude.yaml@v1


### PR DESCRIPTION
Add Claude AI assistant for code review and issue comments.

## What this enables:
- AI analysis and suggestions in PR review comments and issues
- Triggered by mentioning `@claude` in comments
- References reusable workflow from BitGo/github-ai-assistant

## Documentation:
For more information, please see the [Confluence Documentation](https://bitgoinc.atlassian.net/wiki/spaces/ENG/pages/4396285988/GitHub+AI+Assistant).

Ticket: DX-1910