### PR TITLE
feat: add CI check to prevent lockfile modifications

### DIFF
--- a/.github/workflows/prevent-lockfile-modifications.yaml
+++ b/.github/workflows/prevent-lockfile-modifications.yaml
@@ -1,0 +1,9 @@
+name: Prevent lockfile modifications
+on:
+  pull_request:
+jobs:
+  prevent-lockfile-modifications:
+    name: Prevent Lockfile Modifications
+    uses: BitGo/static-analysis/.github/workflows/prevent-lockfile-modifications.yaml@v1
+    secrets:
+      vault-cf-access-client-secret: ${{ secrets.VAULT_CF_ACCESS_CLIENT_SECRET }}


### PR DESCRIPTION
Add GitHub Actions workflow to verify that dependencies added to the project satisfy security and compliance requirements.

This check will become required when https://github.com/BitGo/infra/pull/11932 merges.

Ticket: VL-3536