### PR TITLE
feat: rate limiting for mint /burn operations

### DIFF
--- a/contracts/Stablecoin.sol
+++ b/contracts/Stablecoin.sol
@@ -12,8 +12,9 @@ import "./Blacklistable.sol";
 /**
  * @title Stablecoin - Generic stablecoin contract
  * @dev This contract implements the core ERC-20 stablecoin functionality including:
- * minting, pausing, blacklisting, and permit-based approvals. It is also upgradeable through
- * UUPS (Universal Upgradeable Proxy Standard).
+ * rate-limited minting/burning, pausing, blacklisting, and permit-based approvals. 
+ * It differentiates between native mints (backed by collateral) and bridge mints (cross-chain).
+ * It is upgradeable through UUPS (Universal Upgradeable Proxy Standard).
  * 
  * /// @custom:security-contact security@bitgo.com
  */
@@ -30,6 +31,17 @@ contract Stablecoin is
     bytes32 private constant StablecoinStorageLocation = 
                     0x9b2d10d13c5ae4f59a8184d905810047d3ab7f6fe6302078b828a0112a6ab900;
 
+    /**
+     * @notice The duration it takes for the limits to fully replenish
+     */
+    uint256 private constant _DURATION = 1 days;
+
+    /**
+     * @notice Minimum limit to prevent precision loss in rate calculations
+     * @dev This ensures ratePerSecond is always >= 1 (1 token per second minimum)
+     */
+    uint256 private constant _MIN_LIMIT = 86400; // 1 day in seconds
+
     // --- Roles ---
     /**
      * @dev This role grants the ability to freeze or unfreeze all token transfers within the contract.
@@ -37,10 +49,20 @@ contract Stablecoin is
     bytes32 public constant FREEZER_ROLE = keccak256("FREEZER_ROLE");
 
     /**
-     * @dev This role is responsible for managing the token supply, 
-     * including minting, burning or destroying blacklisted funds.
+     * @dev This role is responsible for administering minters and bridge minters,
+     * including setting limits and destroying blacklisted funds.
      */
-    bytes32 public constant SUPPLY_CONTROLLER_ROLE = keccak256("SUPPLY_CONTROLLER_ROLE");
+    bytes32 public constant MASTER_MINTER_ROLE = keccak256("MASTER_MINTER_ROLE");
+
+    /**
+     * @dev This role allows minting and burning tokens for native operations (backed by collateral, treasury).
+     */
+    bytes32 public constant MINTER = keccak256("MINTER");
+
+    /**
+     * @dev This role allows minting and burning tokens for cross-chain bridge operations.
+     */
+    bytes32 public constant BRIDGE_MINTER = keccak256("BRIDGE_MINTER");
 
     /**
      * @dev This role allows to upgrade the contract, typically for implementing new features or bug fixes.
@@ -52,21 +74,89 @@ contract Stablecoin is
      */
     bytes32 public constant RESCUER_ROLE = keccak256("RESCUER_ROLE");
 
-    // --- Events ---
+    // --- Structs ---
     /**
-     * @dev Emitted when tokens are burned from the `from` address.
+     * @dev Parameters for minting or burning limits
      */
-    event Burn(address indexed from, uint256 amount);
+    struct MinterParams {
+        uint256 maxLimit;           // Maximum tokens per day
+        uint256 currentLimit;       // Currently available capacity
+        uint256 timestamp;          // Last update timestamp
+        uint256 ratePerSecond;      // Replenishment rate
+    }
 
     /**
-     * @dev Emitted when tokens are minted to the `to` address.
+     * @dev Minter configuration with separate mint and burn limits
      */
-    event Mint(address indexed to, uint256 amount);
+    struct MinterConfig {
+        MinterParams minterParams;
+        MinterParams burnerParams;
+        bool isConfigured;
+    }
+
+    // --- Storage Mappings ---
+    /**
+     * @dev Maps native minter addresses to their configurations
+     */
+    mapping(address => MinterConfig) public minters;
+
+    /**
+     * @dev Maps bridge minter addresses to their configurations
+     */
+    mapping(address => MinterConfig) public bridgeMinters;
+
+    // --- Events ---
+    /**
+     * @dev Emitted when tokens are minted natively (backed by collateral, treasury operations).
+     */
+    event MintNative(address indexed minter, address indexed to, uint256 amount);
+
+    /**
+     * @dev Emitted when tokens are burned natively.
+     */
+    event BurnNative(address indexed minter, address indexed from, uint256 amount);
+
+    /**
+     * @dev Emitted when tokens are minted via a bridge.
+     */
+    event MintBridge(address indexed bridge, address indexed to, uint256 amount);
+
+    /**
+     * @dev Emitted when tokens are burned via a bridge.
+     */
+    event BurnBridge(address indexed bridge, address indexed from, uint256 amount);
+
+    /**
+     * @dev Emitted when a native minter is configured.
+     */
+    event MinterConfigured(address indexed minter, uint256 mintLimit, uint256 burnLimit);
+
+    /**
+     * @dev Emitted when a bridge minter is configured.
+     */
+    event BridgeMinterConfigured(address indexed bridge, uint256 mintLimit, uint256 burnLimit);
+
+    /**
+     * @dev Emitted when a native minter is removed.
+     */
+    event MinterRemoved(address indexed minter);
+
+    /**
+     * @dev Emitted when a bridge minter is removed.
+     */
+    event BridgeMinterRemoved(address indexed bridge);
 
     /**
      * @dev Emitted when the mint cap per transaction is set to a new value.
      */
     event MintCapPerTransactionSet(uint256 newLimit);
+    
+    /**
+     * @dev Emitted when an existing minter's limits are updated.
+     */
+    event MinterLimitsUpdated(
+        address indexed minter, uint256 newMintLimit, uint256 newBurnLimit, bool indexed isBridge
+        );
 
     /**
      * @dev Emitted when tokens are rescued from the token address and sent to a `recipient` address.
@@ -114,6 +204,66 @@ contract Stablecoin is
      */
     error ArrayLengthsMismatch();
 
+    /**
+     * @dev The operation failed because the minter is not configured.
+     */
+    error MinterNotConfigured();
+
+    /**
+     * @dev The operation failed because the bridge minter is not configured.
+     */
+    error BridgeMinterNotConfigured();
+
+    /**
+     * @dev The operation failed because the minter has insufficient allowance.
+     */
+    error InsufficientMinterAllowance();
+
+    /**
+     * @dev The operation failed because the burner has insufficient allowance.
+     */
+    error InsufficientBurnerAllowance();
+
+    /**
+     * @dev The operation failed because the limits are set too high (overflow protection).
+     */
+    error LimitsTooHigh();
+
+    /**
+     * @dev The operation failed because the limit is below the minimum required.
+     */
+    error LimitTooLow();
+
+    /**
+     * @dev The operation failed because the account is already a minter.
+     */
+    error AccountAlreadyMinter();
+
+    /**
+     * @dev The operation failed because the account is already a bridge minter.
+     */
+    error AccountAlreadyBridgeMinter();
+
+    /**
+     * @dev The operation failed because the account is not configured as a minter.
+     */
+    error AccountNotConfiguredAsMinter();
+
+    /**
+     * @dev The operation failed because the account is not configured as a bridge minter.
+     */
+    error AccountNotConfiguredAsBridgeMinter();
+
+    /**
+     * @dev The operation failed because the account does not have the minter role.
+     */
+    error AccountMissingMinterRole();
+
+    /**
+     * @dev The operation failed because the account does not have the bridge minter role.
+     */
+    error AccountMissingBridgeMinterRole();
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -139,7 +289,7 @@ contract Stablecoin is
      * @param defaultAdmin The address of the default admin.
      * @param defaultAdminDelay The delay (in seconds) before the default admin can be changed.
      * @param freezer The address of the freezer role.
-     * @param supplyController The address of the supply controller role.
+     * @param masterMinter The address of the master minter role.
      * @param upgrader The address of the upgrader role.
      * @param blacklister The address of the blacklister role.
      * @param rescuer The address of the rescuer role.
@@ -152,7 +302,7 @@ contract Stablecoin is
         address defaultAdmin,
         uint48 defaultAdminDelay,
         address freezer,
-        address supplyController,
+        address masterMinter,
         address upgrader,
         address blacklister,
         address rescuer,
@@ -165,13 +315,437 @@ contract Stablecoin is
         __AccessControlDefaultAdminRules_init(defaultAdminDelay, defaultAdmin);
         _grantRole(BLACKLISTER_ROLE, blacklister);
         _grantRole(FREEZER_ROLE, freezer);
-        _grantRole(SUPPLY_CONTROLLER_ROLE, supplyController);
+        _grantRole(MASTER_MINTER_ROLE, masterMinter);
         _grantRole(UPGRADER_ROLE, upgrader);
         _grantRole(RESCUER_ROLE, rescuer);
         _getStablecoinStorage().mintCapPerTransaction = defaultMintCap;
         emit MintCapPerTransactionSet(_getStablecoinStorage().mintCapPerTransaction);
         _getStablecoinStorage().tokenDecimals = tokenDecimals;
     }
+
+    // --- Master Minter Functions ---
+
+    /**
+     * @dev Internal function to configure a minter with mint and burn limits.
+     * @param account The address of the minter/bridge to configure.
+     * @param mintLimit The daily minting limit.
+     * @param burnLimit The daily burning limit.
+     * @param isBridge Whether this is a bridge minter or a native minter.
+     */
+    function _configureMinterInternal(
+        address account,
+        uint256 mintLimit,
+        uint256 burnLimit,
+        bool isBridge
+    ) internal {
+        if (account == address(0)) revert InvalidAddress();
+        if (mintLimit > (type(uint256).max / 2) || burnLimit > (type(uint256).max / 2)) {
+            revert LimitsTooHigh();
+        }
+        
+        // Validate minimum limits to prevent precision loss
+        if (mintLimit < _MIN_LIMIT) revert LimitTooLow();
+        if (burnLimit < _MIN_LIMIT) revert LimitTooLow();
+
+        // Check that an account can't have both roles simultaneously
+        if (isBridge && hasRole(MINTER, account)) {
+            revert AccountAlreadyMinter();
+        }
+        
+        if (!isBridge && hasRole(BRIDGE_MINTER, account)) {
+            revert AccountAlreadyBridgeMinter();
+        }
+
+        bool isUpdate = false;
+        
+        if (isBridge) {
+            if (bridgeMinters[account].isConfigured) {
+                isUpdate = true;
+            } else {
+                bridgeMinters[account].isConfigured = true;
+                _grantRole(BRIDGE_MINTER, account);
+            }
+        } else {
+            if (minters[account].isConfigured) {
+                isUpdate = true;
+            } else {
+                minters[account].isConfigured = true;
+                _grantRole(MINTER, account);
+            }
+        }
+        
+        _changeMinterLimit(account, mintLimit, isBridge);
+        _changeBurnerLimit(account, burnLimit, isBridge);
+        
+        if (isUpdate) {
+            emit MinterLimitsUpdated(account, mintLimit, burnLimit, isBridge);
+        } else {
+            if (isBridge) {
+                emit BridgeMinterConfigured(account, mintLimit, burnLimit);
+            } else {
+                emit MinterConfigured(account, mintLimit, burnLimit);
+            }
+        }
+    }
+
+    /**
+     * @dev Configures a native minter with mint and burn limits.
+     * @param minter The address of the minter to configure.
+     * @param mintLimit The daily minting limit.
+     * @param burnLimit The daily burning limit.
+     */
+    function configureMinter(
+        address minter,
+        uint256 mintLimit,
+        uint256 burnLimit
+    ) external onlyRole(MASTER_MINTER_ROLE) {
+        _configureMinterInternal(minter, mintLimit, burnLimit, false);
+    }
+
+    /**
+     * @dev Configures a bridge minter with mint and burn limits.
+     * @param bridge The address of the bridge to configure.
+     * @param mintLimit The daily minting limit.
+     * @param burnLimit The daily burning limit.
+     */
+    function configureBridgeMinter(
+        address bridge,
+        uint256 mintLimit,
+        uint256 burnLimit
+    ) external onlyRole(MASTER_MINTER_ROLE) {
+        _configureMinterInternal(bridge, mintLimit, burnLimit, true);
+    }
+
+    /**
+     * @dev Internal function to remove a minter or bridge minter.
+     * @param account The address of the minter/bridge to remove.
+     * @param isBridge Whether this is a bridge minter or a native minter.
+     */
+    function _removeMinterInternal(address account, bool isBridge) internal {
+        MinterConfig storage config = isBridge ? bridgeMinters[account] : minters[account];
+
+        // Check if the account is configured and has the role
+        if (!config.isConfigured) {
+            if (isBridge) {
+                revert AccountNotConfiguredAsBridgeMinter();
+            } else {
+                revert AccountNotConfiguredAsMinter();
+            }
+        }
+
+        if (!hasRole(isBridge ? BRIDGE_MINTER : MINTER, account)) {
+            if (isBridge) {
+                revert AccountMissingBridgeMinterRole();
+            } else {
+                revert AccountMissingMinterRole();
+            }
+        }
+
+        config.isConfigured = false;
+        config.minterParams.maxLimit = 0;
+        config.minterParams.currentLimit = 0;
+        config.burnerParams.maxLimit = 0;
+        config.burnerParams.currentLimit = 0;
+
+        _revokeRole(isBridge ? BRIDGE_MINTER : MINTER, account);
+
+        if (isBridge) {
+            emit BridgeMinterRemoved(account);
+        } else {
+            emit MinterRemoved(account);
+        }
+    }
+
+    /**
+     * @dev Removes a native minter.
+     * @param minter The address of the minter to remove.
+     */
+    function removeMinter(address minter) external onlyRole(MASTER_MINTER_ROLE) {
+        _removeMinterInternal(minter, false);
+    }
+
+    /**
+     * @dev Removes a bridge minter.
+     * @param bridge The address of the bridge to remove.
+     */
+    function removeBridgeMinter(address bridge) external onlyRole(MASTER_MINTER_ROLE) {
+        _removeMinterInternal(bridge, true);
+    }
+
+    /**
+     * @dev Destroys blacklisted funds.
+     * @param account The address of the account with blacklisted funds.
+     */
+    function destroyBlacklistedFunds(
+        address account
+    ) external onlyRole(MASTER_MINTER_ROLE) {
+        if (!isBlacklisted(account)) revert SenderNotBlacklisted();
+        uint256 balance = balanceOf(account);
+        _burn(account, balance);
+        emit BurnNative(msg.sender, account, balance);
+    }
+
+    // --- Minter Functions (Native) ---
+
+    // --- Internal Mint/Burn Implementation ---
+    
+    /**
+     * @dev Internal function for minting tokens with proper checks and limits.
+     * @param to The address to which the new tokens will be minted.
+     * @param amount The amount of tokens to be minted.
+     * @param isBridge Whether this is a bridge mint operation.
+     */
+    function _mintTokens(address to, uint256 amount, bool isBridge) internal {
+        if (isBlacklisted(to)) revert RecipientBlacklisted();
+        if (amount > _getStablecoinStorage().mintCapPerTransaction) revert ExceedsMintTransactionCap();
+        
+        MinterConfig storage config = isBridge ? bridgeMinters[msg.sender] : minters[msg.sender];
+        if (!config.isConfigured) {
+            if (isBridge) {
+                revert BridgeMinterNotConfigured();
+            } else {
+                revert MinterNotConfigured();
+            }
+        }
+        
+        uint256 currentLimit = _getMintingCurrentLimit(msg.sender, isBridge);
+        if (currentLimit < amount) revert InsufficientMinterAllowance();
+        
+        _useMinterLimits(msg.sender, amount, isBridge);
+        _mint(to, amount);
+        
+        if (isBridge) {
+            emit MintBridge(msg.sender, to, amount);
+        } else {
+            emit MintNative(msg.sender, to, amount);
+        }
+    }
+    
+    /**
+     * @dev Internal function for burning tokens with proper checks and limits.
+     * @param from The address from which the tokens will be burned.
+     * @param amount The amount of tokens to be burned.
+     * @param isBridge Whether this is a bridge burn operation.
+     */
+    function _burnTokens(address from, uint256 amount, bool isBridge) internal {
+        if (isBlacklisted(from)) revert SenderBlacklisted();
+        
+        MinterConfig storage config = isBridge ? bridgeMinters[msg.sender] : minters[msg.sender];
+        if (!config.isConfigured) {
+            if (isBridge) {
+                revert BridgeMinterNotConfigured();
+            } else {
+                revert MinterNotConfigured();
+            }
+        }
+        
+        uint256 currentLimit = _getBurningCurrentLimit(msg.sender, isBridge);
+        if (currentLimit < amount) revert InsufficientBurnerAllowance();
+        
+        _useBurnerLimits(msg.sender, amount, isBridge);
+        _burn(from, amount);
+        
+        if (isBridge) {
+            emit BurnBridge(msg.sender, from, amount);
+        } else {
+            emit BurnNative(msg.sender, from, amount);
+        }
+    }
+    
+    /**
+     * @dev Internal function for batch minting tokens with proper checks and limits.
+     * Gas optimized: calculates limit once, validates all inputs, then mints all tokens.
+     * @param toAddresses The addresses to which the new tokens will be minted.
+     * @param amounts The amounts of tokens to be minted for each address.
+     * @param isBridge Whether this is a bridge mint operation.
+     */
+    function _mintTokensBatch(address[] memory toAddresses, uint256[] memory amounts, bool isBridge) internal {
+        if (toAddresses.length != amounts.length) revert ArrayLengthsMismatch();
+        
+        MinterConfig storage config = isBridge ? bridgeMinters[msg.sender] : minters[msg.sender];
+        if (!config.isConfigured) {
+            if (isBridge) {
+                revert BridgeMinterNotConfigured();
+            } else {
+                revert MinterNotConfigured();
+            }
+        }
+        
+        // Calculate current limit once for gas optimization
+        uint256 currentLimit = _getMintingCurrentLimit(msg.sender, isBridge);
+        uint256 totalAmount = 0;
+        uint256 perTxCap = _getStablecoinStorage().mintCapPerTransaction;
+        
+        // First pass: validate all inputs and calculate total
+        for (uint256 i = 0; i < toAddresses.length; i++) {
+            if (amounts[i] > perTxCap) revert ExceedsMintTransactionCap();
+            if (isBlacklisted(toAddresses[i])) revert RecipientBlacklisted();
+            totalAmount += amounts[i];
+        }
+        
+        // Check total against limit once
+        if (currentLimit < totalAmount) revert InsufficientMinterAllowance();
+        
+        // Second pass: mint tokens and emit events
+        for (uint256 i = 0; i < toAddresses.length; i++) {
+            _mint(toAddresses[i], amounts[i]);
+            
+            if (isBridge) {
+                emit MintBridge(msg.sender, toAddresses[i], amounts[i]);
+            } else {
+                emit MintNative(msg.sender, toAddresses[i], amounts[i]);
+            }
+        }
+        
+        // Update limit once at the end
+        _useMinterLimits(msg.sender, totalAmount, isBridge);
+    }
+    
+    // --- Minter Functions (Native) ---
+    
+    /**
+     * @dev Mints new tokens natively (backed by collateral, treasury operations).
+     * @param to The address to which the new tokens will be minted.
+     * @param amount The amount of tokens to be minted.
+     */
+    function mint(address to, uint256 amount) external onlyRole(MINTER) {
+        _mintTokens(to, amount, false);
+    }
+    
+    /**
+     * @dev Burns tokens natively.
+     * @param from The address from which the tokens will be burned.
+     * @param amount The amount of tokens to be burned.
+     */
+    function burn(address from, uint256 amount) external onlyRole(MINTER) {
+        _burnTokens(from, amount, false);
+    }
+    
+    /**
+     * @dev Mints new tokens natively to a set of addresses.
+     * @param toAddresses The addresses to which the new tokens will be minted.
+     * @param amounts The amounts of tokens to be minted for each address.
+     */
+    function mintBatch(address[] memory toAddresses, uint256[] memory amounts) external onlyRole(MINTER) {
+        _mintTokensBatch(toAddresses, amounts, false);
+    }
+    
+    // --- Bridge Minter Functions ---
+    
+    /**
+     * @dev Mints tokens via a bridge for cross-chain operations.
+     * @param to The address to which the new tokens will be minted.
+     * @param amount The amount of tokens to be minted.
+     */
+    function bridgeMint(address to, uint256 amount) external onlyRole(BRIDGE_MINTER) {
+        _mintTokens(to, amount, true);
+    }
+    
+    /**
+     * @dev Burns tokens via a bridge for cross-chain operations.
+     * @param from The address from which the tokens will be burned.
+     * @param amount The amount of tokens to be burned.
+     */
+    function bridgeBurn(address from, uint256 amount) external onlyRole(BRIDGE_MINTER) {
+        _burnTokens(from, amount, true);
+    }
+    
+    /**
+     * @dev Mints tokens via a bridge to a set of addresses.
+     * @param toAddresses The addresses to which the new tokens will be minted.
+     * @param amounts The amounts of tokens to be minted for each address.
+     */
+    function bridgeMintBatch(address[] memory toAddresses, uint256[] memory amounts) external onlyRole(BRIDGE_MINTER) {
+        _mintTokensBatch(toAddresses, amounts, true);
+    }
+
+    // --- View Functions ---
+
+    /**
+     * @dev Returns the maximum minting limit for a minter.
+     * @param minter The address of the minter.
+     * @param isBridge Whether this is a bridge minter.
+     * @return The maximum minting limit.
+     */
+    function mintingMaxLimitOf(address minter, bool isBridge) public view returns (uint256) {
+        if (isBridge) {
+            return bridgeMinters[minter].minterParams.maxLimit;
+        } else {
+            return minters[minter].minterParams.maxLimit;
+        }
+    }
+
+    /**
+     * @dev Returns the maximum burning limit for a minter.
+     * @param minter The address of the minter.
+     * @param isBridge Whether this is a bridge minter.
+     * @return The maximum burning limit.
+     */
+    function burningMaxLimitOf(address minter, bool isBridge) public view returns (uint256) {
+        if (isBridge) {
+            return bridgeMinters[minter].burnerParams.maxLimit;
+        } else {
+            return minters[minter].burnerParams.maxLimit;
+        }
+    }
+
+    /**
+     * @dev Returns the current available minting limit for a minter.
+     * @param minter The address of the minter.
+     * @param isBridge Whether this is a bridge minter.
+     * @return The current minting limit.
+     */
+    function mintingCurrentLimitOf(address minter, bool isBridge) public view returns (uint256) {
+        return _getMintingCurrentLimit(minter, isBridge);
+    }
+
+    /**
+     * @dev Returns the current available burning limit for a minter.
+     * @param minter The address of the minter.
+     * @param isBridge Whether this is a bridge minter.
+     * @return The current burning limit.
+     */
+    function burningCurrentLimitOf(address minter, bool isBridge) public view returns (uint256) {
+        return _getBurningCurrentLimit(minter, isBridge);
+    }
+
+    /**
+     * @dev Checks if an address is a configured native minter.
+     * @param account The address to check.
+     * @return True if the address is a configured minter.
+     */
+    function isMinter(address account) external view returns (bool) {
+        return minters[account].isConfigured;
+    }
+
+    /**
+     * @dev Checks if an address is a configured bridge minter.
+     * @param account The address to check.
+     * @return True if the address is a configured bridge minter.
+     */
+    function isBridgeMinter(address account) external view returns (bool) {
+        return bridgeMinters[account].isConfigured;
+    }
+
+    /**
+     * @dev Returns the current minting allowance (alias for mintingCurrentLimitOf).
+     * @param minter The address of the minter.
+     * @return The current minting allowance.
+     */
+    function minterAllowance(address minter) external view returns (uint256) {
+        return _getMintingCurrentLimit(minter, false);
+    }
+
+    /**
+     * @dev Returns the current minting allowance for a bridge (alias for mintingCurrentLimitOf).
+     * @param bridge The address of the bridge.
+     * @return The current minting allowance.
+     */
+    function bridgeMinterAllowance(address bridge) external view returns (uint256) {
+        return _getMintingCurrentLimit(bridge, true);
+    }
+
+    // --- Admin Functions ---
 
     /**
      * @dev Sets the mint cap per transaction.
@@ -185,19 +759,6 @@ contract Stablecoin is
         if (newLimit <= 0) revert InvalidAmount();
         _getStablecoinStorage().mintCapPerTransaction = newLimit;
         emit MintCapPerTransactionSet(newLimit);
-    }
-
-    /**
-     * @dev Destroys blacklisted funds.
-     * @param account The address of the account with blacklisted funds.
-     */
-    function destroyBlacklistedFunds(
-        address account
-    ) external onlyRole(SUPPLY_CONTROLLER_ROLE) {
-        if (!isBlacklisted(account)) revert SenderNotBlacklisted();
-        uint256 balance = balanceOf(account);
-        _burn(account, balance);
-        emit Burn(account, balance);
     }
 
     /**
@@ -232,6 +793,8 @@ contract Stablecoin is
         _unpause();
     }
 
+    // --- ERC20 Overrides ---
+
     /**
      * @dev Transfers `value` tokens from `from` to `to` address 
      * using the allowance mechanism. `value` is then deducted 
@@ -263,54 +826,6 @@ contract Stablecoin is
     ) public virtual override returns (bool) {
         if (isBlacklisted(_msgSender())) revert SenderBlacklisted();
         return super.transfer(to, value);
-    }
-
-    /**
-     * @dev Mints new tokens and assigns them to an address.
-     * @param to The address to which the new tokens will be minted.
-     * @param amount The amount of tokens to be minted.
-     */
-    function mint(
-        address to,
-        uint256 amount
-    ) external onlyRole(SUPPLY_CONTROLLER_ROLE) {
-        if (isBlacklisted(to)) revert RecipientBlacklisted();
-        if (amount > _getStablecoinStorage().mintCapPerTransaction) revert ExceedsMintTransactionCap();
-        _mint(to, amount);
-        emit Mint(to, amount);
-    }
-
-    /**
-     * @dev Mints new tokens and assigns them to a set of addresses.
-     * @param toAddresses The addresses to which the new tokens will be minted.
-     * @param amounts The amounts of tokens to be minted for each address.
-     */
-    function mintBatch(
-        address[] memory toAddresses,
-        uint256[] memory amounts
-    ) external onlyRole(SUPPLY_CONTROLLER_ROLE) {
-        if (toAddresses.length != amounts.length) revert ArrayLengthsMismatch();
-        for (uint256 i = 0; i < toAddresses.length; i++) {
-            if (amounts[i] > _getStablecoinStorage().mintCapPerTransaction) revert ExceedsMintTransactionCap();
-            if (isBlacklisted(toAddresses[i])) revert RecipientBlacklisted();
-            _mint(toAddresses[i], amounts[i]);
-            emit Mint(toAddresses[i], amounts[i]);
-        }
-    }
-
-    /**
-     * @dev Burns tokens from `from` address. Action is restricted 
-     * to the supply controller role.
-     * @param from The address from which the tokens will be burned.
-     * @param amount The amount of tokens to be burned.
-     */
-    function burn(
-        address from,
-        uint256 amount
-    ) external onlyRole(SUPPLY_CONTROLLER_ROLE) {
-        if (isBlacklisted(from)) revert SenderBlacklisted();
-        _burn(from, amount);
-        emit Burn(from, amount);
     }
 
     /**
@@ -351,6 +866,8 @@ contract Stablecoin is
         return Blacklistable.balanceOf(account);
     }
 
+    // --- Internal Functions ---
+
     /**
      * @dev Authorizes the upgrade to a new implementation contract.
      * @param newImplementation The address of the new implementation contract.
@@ -373,13 +890,165 @@ contract Stablecoin is
         internal
         override(Blacklistable, ERC20Upgradeable, ERC20PausableUpgradeable)
     {
-        // This will trigger the ERC20PausableUpgradeable._update
-        // enforcing the pausable feature and then
-        // will trigger the Blacklistable._update
-        // since ERC20PausableUpgradeable is inherited after Blacklistable
-        // This won't trigger the ERC20Upgradeable._update
-        // since we are not calling super._update in Blacklistable._update
         ERC20PausableUpgradeable._update(from, to, value);
+    }
+
+    /**
+     * @dev Gets the current minting limit for a minter, accounting for time-based replenishment.
+     * @param minter The address of the minter.
+     * @param isBridge Whether this is a bridge minter.
+     * @return The current minting limit.
+     */
+    function _getMintingCurrentLimit(address minter, bool isBridge) internal view returns (uint256) {
+        MinterConfig storage config = isBridge ? bridgeMinters[minter] : minters[minter];
+        return _getCurrentLimit(
+            config.minterParams.currentLimit,
+            config.minterParams.maxLimit,
+            config.minterParams.timestamp,
+            config.minterParams.ratePerSecond
+        );
+    }
+
+    /**
+     * @dev Gets the current burning limit for a minter, accounting for time-based replenishment.
+     * @param minter The address of the minter.
+     * @param isBridge Whether this is a bridge minter.
+     * @return The current burning limit.
+     */
+    function _getBurningCurrentLimit(address minter, bool isBridge) internal view returns (uint256) {
+        MinterConfig storage config = isBridge ? bridgeMinters[minter] : minters[minter];
+        return _getCurrentLimit(
+            config.burnerParams.currentLimit,
+            config.burnerParams.maxLimit,
+            config.burnerParams.timestamp,
+            config.burnerParams.ratePerSecond
+        );
+    }
+
+    /**
+     * @dev Calculates the current limit with time-based replenishment.
+     * @param currentLimit The current limit value.
+     * @param maxLimit The maximum limit value.
+     * @param timestamp The last update timestamp.
+     * @param ratePerSecond The replenishment rate per second.
+     * @return limit The calculated current limit.
+     */
+    function _getCurrentLimit(
+        uint256 currentLimit,
+        uint256 maxLimit,
+        uint256 timestamp,
+        uint256 ratePerSecond
+    ) internal view returns (uint256 limit) {
+        limit = currentLimit;
+        if (limit == maxLimit) {
+            return limit;
+        } else if (timestamp + _DURATION <= block.timestamp) {
+            limit = maxLimit;
+        } else if (timestamp + _DURATION > block.timestamp) {
+            uint256 timePassed = block.timestamp - timestamp;
+            uint256 calculatedLimit = limit + (timePassed * ratePerSecond);
+            limit = calculatedLimit > maxLimit ? maxLimit : calculatedLimit;
+        }
+    }
+
+    /**
+     * @dev Uses the minter's limit by reducing the current limit.
+     * @param minter The address of the minter.
+     * @param amount The amount to reduce from the limit.
+     * @param isBridge Whether this is a bridge minter.
+     */
+    function _useMinterLimits(address minter, uint256 amount, bool isBridge) internal {
+        MinterConfig storage config = isBridge ? bridgeMinters[minter] : minters[minter];
+        uint256 currentLimit = _getCurrentLimit(
+            config.minterParams.currentLimit,
+            config.minterParams.maxLimit,
+            config.minterParams.timestamp,
+            config.minterParams.ratePerSecond
+        );
+        config.minterParams.timestamp = block.timestamp;
+        config.minterParams.currentLimit = currentLimit - amount;
+    }
+
+    /**
+     * @dev Uses the burner's limit by reducing the current limit.
+     * @param minter The address of the minter.
+     * @param amount The amount to reduce from the limit.
+     * @param isBridge Whether this is a bridge minter.
+     */
+    function _useBurnerLimits(address minter, uint256 amount, bool isBridge) internal {
+        MinterConfig storage config = isBridge ? bridgeMinters[minter] : minters[minter];
+        uint256 currentLimit = _getCurrentLimit(
+            config.burnerParams.currentLimit,
+            config.burnerParams.maxLimit,
+            config.burnerParams.timestamp,
+            config.burnerParams.ratePerSecond
+        );
+        config.burnerParams.timestamp = block.timestamp;
+        config.burnerParams.currentLimit = currentLimit - amount;
+    }
+
+    /**
+     * @dev Updates the minting limit for a minter.
+     * @param minter The address of the minter.
+     * @param limit The new limit value.
+     * @param isBridge Whether this is a bridge minter.
+     */
+    function _changeMinterLimit(address minter, uint256 limit, bool isBridge) internal {
+        MinterConfig storage config = isBridge ? bridgeMinters[minter] : minters[minter];
+        uint256 oldLimit = config.minterParams.maxLimit;
+        uint256 currentLimit = _getCurrentLimit(
+            config.minterParams.currentLimit,
+            config.minterParams.maxLimit,
+            config.minterParams.timestamp,
+            config.minterParams.ratePerSecond
+        );
+        config.minterParams.maxLimit = limit;
+        config.minterParams.currentLimit = _calculateNewCurrentLimit(limit, oldLimit, currentLimit);
+        config.minterParams.ratePerSecond = limit / _DURATION;
+        config.minterParams.timestamp = block.timestamp;
+    }
+
+    /**
+     * @dev Updates the burning limit for a minter.
+     * @param minter The address of the minter.
+     * @param limit The new limit value.
+     * @param isBridge Whether this is a bridge minter.
+     */
+    function _changeBurnerLimit(address minter, uint256 limit, bool isBridge) internal {
+        MinterConfig storage config = isBridge ? bridgeMinters[minter] : minters[minter];
+        uint256 oldLimit = config.burnerParams.maxLimit;
+        uint256 currentLimit = _getCurrentLimit(
+            config.burnerParams.currentLimit,
+            config.burnerParams.maxLimit,
+            config.burnerParams.timestamp,
+            config.burnerParams.ratePerSecond
+        );
+        config.burnerParams.maxLimit = limit;
+        config.burnerParams.currentLimit = _calculateNewCurrentLimit(limit, oldLimit, currentLimit);
+        config.burnerParams.ratePerSecond = limit / _DURATION;
+        config.burnerParams.timestamp = block.timestamp;
+    }
+
+    /**
+     * @dev Calculates the new current limit when the max limit changes.
+     * @param newLimit The new maximum limit.
+     * @param oldLimit The old maximum limit.
+     * @param currentLimit The current limit value.
+     * @return newCurrentLimit The adjusted current limit.
+     */
+    function _calculateNewCurrentLimit(
+        uint256 newLimit,
+        uint256 oldLimit,
+        uint256 currentLimit
+    ) internal pure returns (uint256 newCurrentLimit) {
+        uint256 difference;
+        if (oldLimit > newLimit) {
+            difference = oldLimit - newLimit;
+            newCurrentLimit = currentLimit > difference ? currentLimit - difference : 0;
+        } else {
+            difference = newLimit - oldLimit;
+            newCurrentLimit = currentLimit + difference;
+        }
     }
 
     /**

--- a/test/blacklist.ts
+++ b/test/blacklist.ts
@@ -7,19 +7,22 @@ describe("blacklist", function () {
   let contractInstance: Stablecoin;
   let defaultAdmin: SignerWithAddress;
   let freezer: SignerWithAddress;
-  let supplyController: SignerWithAddress;
+  let masterMinter: SignerWithAddress;
+  let minter: SignerWithAddress;
   let upgrader: SignerWithAddress;
   let reserve: SignerWithAddress;
   let blacklister: SignerWithAddress;
   let targetAccount: SignerWithAddress;
   let withdrawer: SignerWithAddress;
   const addressZero = "0x0000000000000000000000000000000000000000";
+  const DAILY_LIMIT = ethers.parseUnits("10000000", 6); // 10M tokens daily limit
 
   before(async function () {
     [
       defaultAdmin,
       freezer,
-      supplyController,
+      masterMinter,
+      minter,
       upgrader,
       blacklister,
       reserve,
@@ -38,7 +41,7 @@ describe("blacklist", function () {
         defaultAdmin.address,
         defaultAdminDelay,
         freezer.address,
-        supplyController.address,
+        masterMinter.address,
         upgrader.address,
         blacklister.address,
         withdrawer.address,
@@ -48,9 +51,12 @@ describe("blacklist", function () {
     );
     contractInstance = (await contract.waitForDeployment()) as unknown as Stablecoin;
 
+    // Configure minter with high limits for testing
+    await contractInstance.connect(masterMinter).configureMinter(minter.address, DAILY_LIMIT, DAILY_LIMIT);
+
     // Mint tokens to reserve
     await contractInstance
-      .connect(supplyController)
+      .connect(minter)
       .mint(reserve.address, 1000);
   });
 
@@ -287,7 +293,7 @@ describe("blacklist", function () {
     expect(receiverBalanceBefore).to.equal(receiverBalanceAfter);
   });
 
-  it("Should allow supply controller role to destroy blacklisted funds", async function () {
+  it("Should allow master minter role to destroy blacklisted funds", async function () {
     // Blacklist receiver
     await contractInstance
       .connect(blacklister)
@@ -300,13 +306,13 @@ describe("blacklist", function () {
     // Destroy blacklisted funds
     await expect(
       contractInstance
-        .connect(supplyController)
+        .connect(masterMinter)
         .destroyBlacklistedFunds(targetAccount.address)
     )
       .to.emit(contractInstance, "Transfer")
       .withArgs(targetAccount.address, addressZero, 750)
-      .to.emit(contractInstance, "Burn")
-      .withArgs(targetAccount.address, 750);
+      .to.emit(contractInstance, "BurnNative")
+      .withArgs(masterMinter.address, targetAccount.address, 750);
     const targetBalanceAfter = await contractInstance.balanceOf(
       targetAccount.address
     );
@@ -318,10 +324,10 @@ describe("blacklist", function () {
     expect(isBlacklisted).to.be.true;
   });
 
-  it("Should prevent non-blacklister from destroying blacklisted funds", async function () {
+  it("Should prevent non-master-minter from destroying blacklisted funds", async function () {
     // Blacklist receiver
     await contractInstance
-      .connect(supplyController)
+      .connect(minter)
       .mint(targetAccount.address, 1000);
     await contractInstance
       .connect(blacklister)
@@ -331,7 +337,7 @@ describe("blacklist", function () {
     );
     expect(targetBalance).to.equal(1000);
 
-    // Attempt to destroy blacklisted funds by a non-blacklister
+    // Attempt to destroy blacklisted funds by a non-master-minter
     try {
       await contractInstance
         .connect(defaultAdmin)
@@ -357,7 +363,7 @@ describe("blacklist", function () {
     // Attempt to mint tokens to the blacklisted address
     try {
       await contractInstance
-        .connect(supplyController)
+        .connect(minter)
         .mint(targetAccount.address, 100);
     } catch (error) {
       expect(error).to.be.an("error");

--- a/test/pause.ts
+++ b/test/pause.ts
@@ -7,24 +7,32 @@ describe("pause", function () {
   let contractInstance: Stablecoin;
   let defaultAdmin: SignerWithAddress;
   let freezer: SignerWithAddress;
-  let supplyController: SignerWithAddress;
+  let masterMinter: SignerWithAddress;
+  let minter: SignerWithAddress;
   let upgrader: SignerWithAddress;
-  let reserve: SignerWithAddress;
+  let reserve1: SignerWithAddress;
+  let reserve2: SignerWithAddress;
   let blacklister: SignerWithAddress;
-  let withdrawer: SignerWithAddress;
+  let rescuer: SignerWithAddress;
+  let randomAddress: SignerWithAddress;
+  const DAILY_LIMIT = ethers.parseUnits("10000000", 6); // 10M tokens daily limit
 
   before(async function () {
     [
       defaultAdmin,
       freezer,
-      supplyController,
+      masterMinter,
+      minter,
       upgrader,
       blacklister,
-      reserve,
-      withdrawer
+      rescuer,
+      reserve1,
+      reserve2,
+      randomAddress,
     ] = await ethers.getSigners();
     const ContractFactory = await ethers.getContractFactory("Stablecoin");
     const defaultAdminDelay = 7 * 24 * 60 * 60; // 7 days in seconds (or any appropriate value)
+
     const contract = await upgrades.deployProxy(
       ContractFactory,
       [
@@ -34,44 +42,44 @@ describe("pause", function () {
         defaultAdmin.address,
         defaultAdminDelay,
         freezer.address,
-        supplyController.address,
+        masterMinter.address,
         upgrader.address,
         blacklister.address,
-        withdrawer.address,
+        rescuer.address,
         1000000 * (10 ** 6)
       ],
       { kind: "uups" }
     );
-    contractInstance = (await contract.waitForDeployment()) as unknown as Stablecoin;
+    contractInstance =
+      (await contract.waitForDeployment()) as unknown as Stablecoin;
+    
+    // Configure minter with high limits for testing
+    await contractInstance.connect(masterMinter).configureMinter(minter.address, DAILY_LIMIT, DAILY_LIMIT);
   });
 
   it("Should not be able to pause as unauthorized address", async function () {
+    let failed = false;
     try {
-      await contractInstance.connect(defaultAdmin).pause();
+      await contractInstance.connect(randomAddress).pause();
     } catch (error) {
+      failed = true;
       expect(error).to.be.an("error");
     }
-
-    const paused = await contractInstance.paused();
-    expect(paused).to.be.false;
+    expect(failed).to.be.true;
   });
 
   it("Should pause the token successfully by freezer", async function () {
-    // Freezer pauses the token
-    await expect(contractInstance.connect(freezer).pause()).to.emit(
-      contractInstance,
-      "Paused"
-    );
-    const paused = await contractInstance.paused();
-    expect(paused).to.be.true;
+    await expect(contractInstance.connect(freezer).pause())
+      .to.emit(contractInstance, "Paused")
+      .withArgs(freezer.address);
   });
 
   it("Should fail to mint tokens when the token is paused", async function () {
-    const mintAmount = ethers.parseUnits("1000", 1);
+    const mintAmount = ethers.parseUnits("1000", 6);
+
     let failed = false;
     try {
-      // Attempt to mint tokens while the token is paused
-      await contractInstance.connect(supplyController).mint(reserve.address, mintAmount);
+      await contractInstance.connect(minter).mint(reserve1.address, mintAmount);
     } catch (error) {
       failed = true;
       expect((error as Error).message).equal(
@@ -79,15 +87,16 @@ describe("pause", function () {
       );
       expect(error).to.be.an("error");
     }
+
     expect(failed).to.be.true;
   });
 
   it("Should fail to burn tokens when the token is paused", async function () {
-    const burnAmount = ethers.parseUnits("500", 18);
+    const burnAmount = ethers.parseUnits("500", 6);
+
     let failed = false;
     try {
-      // Attempt to burn tokens while the token is paused
-      await contractInstance.connect(supplyController).burn(reserve.address, burnAmount);
+      await contractInstance.connect(minter).burn(reserve1.address, burnAmount);
     } catch (error) {
       failed = true;
       expect((error as Error).message).equal(
@@ -95,18 +104,17 @@ describe("pause", function () {
       );
       expect(error).to.be.an("error");
     }
+
     expect(failed).to.be.true;
   });
 
   it("Should fail to transfer tokens when the token is paused", async function () {
-    const transferAmount = ethers.parseUnits("100", 18);
-    // Assume accounts[0] has tokens and is trying to transfer to recipient
+    const transferAmount = ethers.parseUnits("500", 6);
     let failed = false;
     try {
-      // Attempt to transfer tokens while the token is paused
       await contractInstance
-        .connect(defaultAdmin)
-        .transfer(reserve.address, transferAmount);
+        .connect(reserve1)
+        .transfer(reserve2.address, transferAmount);
     } catch (error) {
       failed = true;
       expect((error as Error).message).equal(
@@ -114,16 +122,13 @@ describe("pause", function () {
       );
       expect(error).to.be.an("error");
     }
+
     expect(failed).to.be.true;
   });
 
   it("Should unpause the token successfully by freezer", async function () {
-    // Freezer unpauses the token
-    await expect(contractInstance.connect(freezer).unpause()).to.emit(
-      contractInstance,
-      "Unpaused"
-    );
-    const paused = await contractInstance.paused();
-    expect(paused).to.be.false;
+    await expect(contractInstance.connect(freezer).unpause())
+      .to.emit(contractInstance, "Unpaused")
+      .withArgs(freezer.address);
   });
 });

--- a/test/rate-limiting.ts
+++ b/test/rate-limiting.ts
@@ -1,0 +1,680 @@
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+import { Stablecoin } from "../typechain-types";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+describe("Rate Limiting - Master Minter, Minter, and Bridge Minter", function () {
+  let contractInstance: Stablecoin;
+  let defaultAdmin: SignerWithAddress;
+  let freezer: SignerWithAddress;
+  let masterMinter: SignerWithAddress;
+  let minter1: SignerWithAddress;
+  let minter2: SignerWithAddress;
+  let bridgeMinter1: SignerWithAddress;
+  let bridgeMinter2: SignerWithAddress;
+  let upgrader: SignerWithAddress;
+  let blacklister: SignerWithAddress;
+  let rescuer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+  let randomAddress: SignerWithAddress;
+
+  const MASTER_MINTER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("MASTER_MINTER_ROLE"));
+  const MINTER = ethers.keccak256(ethers.toUtf8Bytes("MINTER"));
+  const BRIDGE_MINTER = ethers.keccak256(ethers.toUtf8Bytes("BRIDGE_MINTER"));
+  const addressZero = "0x0000000000000000000000000000000000000000";
+
+  // 1M tokens with 6 decimals
+  const DAILY_MINT_LIMIT = ethers.parseUnits("1000000", 6);
+  const DAILY_BURN_LIMIT = ethers.parseUnits("1000000", 6);
+  const PER_TX_CAP = ethers.parseUnits("500000", 6);
+
+  before(async function () {
+    [
+      defaultAdmin,
+      freezer,
+      masterMinter,
+      upgrader,
+      blacklister,
+      rescuer,
+      minter1,
+      minter2,
+      bridgeMinter1,
+      bridgeMinter2,
+      user1,
+      user2,
+      randomAddress,
+    ] = await ethers.getSigners();
+
+    const ContractFactory = await ethers.getContractFactory("Stablecoin");
+    const defaultAdminDelay = 7 * 24 * 60 * 60; // 7 days
+    const contract = await upgrades.deployProxy(
+      ContractFactory,
+      [
+        "GoUSD",
+        "GoUSD",
+        6,
+        defaultAdmin.address,
+        defaultAdminDelay,
+        freezer.address,
+        masterMinter.address,
+        upgrader.address,
+        blacklister.address,
+        rescuer.address,
+        PER_TX_CAP
+      ],
+      { kind: "uups" }
+    );
+    contractInstance = (await contract.waitForDeployment()) as unknown as Stablecoin;
+  });
+
+  describe("Master Minter Role", function () {
+    it("Should have master minter role assigned correctly", async function () {
+      expect(await contractInstance.hasRole(MASTER_MINTER_ROLE, masterMinter.address)).to.be.true;
+    });
+
+    it("Should configure a native minter successfully", async function () {
+      await expect(
+        contractInstance
+          .connect(masterMinter)
+          .configureMinter(minter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT)
+      )
+        .to.emit(contractInstance, "MinterConfigured")
+        .withArgs(minter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+
+      expect(await contractInstance.hasRole(MINTER, minter1.address)).to.be.true;
+      expect(await contractInstance.isMinter(minter1.address)).to.be.true;
+      expect(await contractInstance.mintingMaxLimitOf(minter1.address, false)).to.equal(DAILY_MINT_LIMIT);
+      expect(await contractInstance.burningMaxLimitOf(minter1.address, false)).to.equal(DAILY_BURN_LIMIT);
+    });
+
+    it("Should configure a bridge minter successfully", async function () {
+      await expect(
+        contractInstance
+          .connect(masterMinter)
+          .configureBridgeMinter(bridgeMinter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT)
+      )
+        .to.emit(contractInstance, "BridgeMinterConfigured")
+        .withArgs(bridgeMinter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+
+      expect(await contractInstance.hasRole(BRIDGE_MINTER, bridgeMinter1.address)).to.be.true;
+      expect(await contractInstance.isBridgeMinter(bridgeMinter1.address)).to.be.true;
+      expect(await contractInstance.mintingMaxLimitOf(bridgeMinter1.address, true)).to.equal(DAILY_MINT_LIMIT);
+      expect(await contractInstance.burningMaxLimitOf(bridgeMinter1.address, true)).to.equal(DAILY_BURN_LIMIT);
+    });
+
+    it("Should fail to configure minter with address zero", async function () {
+      await expect(
+        contractInstance
+          .connect(masterMinter)
+          .configureMinter(addressZero, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT)
+      ).to.be.revertedWithCustomError(contractInstance, "InvalidAddress");
+    });
+
+    it("Should fail to configure minter with too high limits", async function () {
+      const tooHighLimit = ethers.MaxUint256 / 2n + 1n;
+      await expect(
+        contractInstance
+          .connect(masterMinter)
+          .configureMinter(minter2.address, tooHighLimit, DAILY_BURN_LIMIT)
+      ).to.be.revertedWithCustomError(contractInstance, "LimitsTooHigh");
+    });
+
+    it("Should fail to configure minter when called by non-master-minter", async function () {
+      await expect(
+        contractInstance
+          .connect(randomAddress)
+          .configureMinter(randomAddress.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT)
+      ).to.be.reverted;
+    });
+
+    it("Should update minter limits successfully", async function () {
+      const newMintLimit = ethers.parseUnits("2000000", 6);
+      const newBurnLimit = ethers.parseUnits("2000000", 6);
+
+      // When updating an existing minter, it emits MinterLimitsUpdated, not MinterConfigured
+      await expect(
+        contractInstance
+          .connect(masterMinter)
+          .configureMinter(minter1.address, newMintLimit, newBurnLimit)
+      )
+        .to.emit(contractInstance, "MinterLimitsUpdated")
+        .withArgs(minter1.address, newMintLimit, newBurnLimit, false);
+
+      expect(await contractInstance.mintingMaxLimitOf(minter1.address, false)).to.equal(newMintLimit);
+      expect(await contractInstance.burningMaxLimitOf(minter1.address, false)).to.equal(newBurnLimit);
+    });
+
+    it("Should remove a native minter successfully", async function () {
+      await expect(
+        contractInstance.connect(masterMinter).removeMinter(minter1.address)
+      )
+        .to.emit(contractInstance, "MinterRemoved")
+        .withArgs(minter1.address);
+
+      expect(await contractInstance.hasRole(MINTER, minter1.address)).to.be.false;
+      expect(await contractInstance.isMinter(minter1.address)).to.be.false;
+      expect(await contractInstance.mintingMaxLimitOf(minter1.address, false)).to.equal(0);
+    });
+
+    it("Should remove a bridge minter successfully", async function () {
+      await expect(
+        contractInstance.connect(masterMinter).removeBridgeMinter(bridgeMinter1.address)
+      )
+        .to.emit(contractInstance, "BridgeMinterRemoved")
+        .withArgs(bridgeMinter1.address);
+
+      expect(await contractInstance.hasRole(BRIDGE_MINTER, bridgeMinter1.address)).to.be.false;
+      expect(await contractInstance.isBridgeMinter(bridgeMinter1.address)).to.be.false;
+      expect(await contractInstance.mintingMaxLimitOf(bridgeMinter1.address, true)).to.equal(0);
+    });
+  });
+
+  describe("Native Minter Operations", function () {
+    before(async function () {
+      // Re-configure minter1 for tests
+      await contractInstance
+        .connect(masterMinter)
+        .configureMinter(minter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+    });
+
+    it("Should mint tokens natively within limits", async function () {
+      const mintAmount = ethers.parseUnits("100000", 6);
+
+      await expect(
+        contractInstance.connect(minter1).mint(user1.address, mintAmount)
+      )
+        .to.emit(contractInstance, "MintNative")
+        .withArgs(minter1.address, user1.address, mintAmount)
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(addressZero, user1.address, mintAmount);
+
+      expect(await contractInstance.balanceOf(user1.address)).to.equal(mintAmount);
+      
+      // Check limit was reduced
+      const currentLimit = await contractInstance.mintingCurrentLimitOf(minter1.address, false);
+      expect(currentLimit).to.equal(DAILY_MINT_LIMIT - mintAmount);
+    });
+
+    it("Should fail to mint when minter is not configured", async function () {
+      const mintAmount = ethers.parseUnits("100000", 6);
+
+      await expect(
+        contractInstance.connect(randomAddress).mint(user1.address, mintAmount)
+      ).to.be.reverted;
+    });
+
+    it("Should fail to mint exceeding daily limit", async function () {
+      // Remove and re-configure minter with fresh limits for this test
+      await contractInstance.connect(masterMinter).removeMinter(minter1.address);
+      await contractInstance.connect(masterMinter).configureMinter(minter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+      
+      // Use up most of the daily limit with multiple transactions to stay under per-tx cap
+      // Mint 500k twice to use 1M out of daily limit, leaving very little
+      await contractInstance.connect(minter1).mint(user1.address, PER_TX_CAP);
+      await contractInstance.connect(minter1).mint(user1.address, PER_TX_CAP);
+      
+      // Now we should have used about 1M, check remaining
+      const remainingLimit = await contractInstance.minterAllowance(minter1.address);
+      
+      // Try to mint more than what's left (should be ~100k or less remaining)
+      const exceedingAmount = remainingLimit + ethers.parseUnits("10000", 6);
+
+      await expect(
+        contractInstance.connect(minter1).mint(user1.address, exceedingAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "InsufficientMinterAllowance");
+    });
+
+    it("Should fail to mint exceeding per-transaction cap", async function () {
+      const exceedingAmount = PER_TX_CAP + 1n;
+
+      await expect(
+        contractInstance.connect(minter1).mint(user1.address, exceedingAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "ExceedsMintTransactionCap");
+    });
+
+    it("Should fail to mint to blacklisted address", async function () {
+      await contractInstance.connect(blacklister).blacklist(user2.address);
+      const mintAmount = ethers.parseUnits("100000", 6);
+
+      await expect(
+        contractInstance.connect(minter1).mint(user2.address, mintAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "RecipientBlacklisted");
+
+      await contractInstance.connect(blacklister).unblacklist(user2.address);
+    });
+
+    it("Should burn tokens natively within limits", async function () {
+      const burnAmount = ethers.parseUnits("50000", 6);
+      const balanceBefore = await contractInstance.balanceOf(user1.address);
+
+      await expect(
+        contractInstance.connect(minter1).burn(user1.address, burnAmount)
+      )
+        .to.emit(contractInstance, "BurnNative")
+        .withArgs(minter1.address, user1.address, burnAmount)
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(user1.address, addressZero, burnAmount);
+
+      expect(await contractInstance.balanceOf(user1.address)).to.equal(balanceBefore - burnAmount);
+    });
+
+    it("Should fail to burn exceeding daily limit", async function () {
+      // First, use up most of the burn limit by burning tokens
+      const user1Balance = await contractInstance.balanceOf(user1.address);
+      const currentBurnLimit = await contractInstance.burningCurrentLimitOf(minter1.address, false);
+      
+      // Burn most of the available limit, leaving only 1000 tokens
+      const amountToBurn = currentBurnLimit - ethers.parseUnits("1000", 6);
+      
+      if (amountToBurn > 0n && amountToBurn <= user1Balance) {
+        await contractInstance.connect(minter1).burn(user1.address, amountToBurn);
+      }
+      
+      // Now try to burn more than what's left in the daily limit
+      const remainingLimit = await contractInstance.burningCurrentLimitOf(minter1.address, false);
+      const exceedingAmount = remainingLimit + ethers.parseUnits("1000", 6);
+
+      await expect(
+        contractInstance.connect(minter1).burn(user1.address, exceedingAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "InsufficientBurnerAllowance");
+    });
+
+    it("Should mint batch successfully within limits", async function () {
+      // Reset minter limits for this test
+      await contractInstance.connect(masterMinter).removeMinter(minter1.address);
+      await contractInstance.connect(masterMinter).configureMinter(minter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+      
+      const amounts = [
+        ethers.parseUnits("10000", 6),
+        ethers.parseUnits("20000", 6),
+        ethers.parseUnits("30000", 6),
+      ];
+      const addresses = [user1.address, user2.address, randomAddress.address];
+
+      await expect(
+        contractInstance.connect(minter1).mintBatch(addresses, amounts)
+      )
+        .to.emit(contractInstance, "MintNative")
+        .withArgs(minter1.address, user1.address, amounts[0]);
+
+      expect(await contractInstance.balanceOf(addresses[2])).to.equal(amounts[2]);
+    });
+
+    it("Should fail mint batch with mismatched array lengths", async function () {
+      const amounts = [ethers.parseUnits("10000", 6), ethers.parseUnits("20000", 6)];
+      const addresses = [user1.address];
+
+      await expect(
+        contractInstance.connect(minter1).mintBatch(addresses, amounts)
+      ).to.be.revertedWithCustomError(contractInstance, "ArrayLengthsMismatch");
+    });
+  });
+
+  describe("Bridge Minter Operations", function () {
+    before(async function () {
+      // Re-configure bridgeMinter1 for tests
+      await contractInstance
+        .connect(masterMinter)
+        .configureBridgeMinter(bridgeMinter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+    });
+
+    it("Should mint tokens via bridge within limits", async function () {
+      const mintAmount = ethers.parseUnits("100000", 6);
+
+      await expect(
+        contractInstance.connect(bridgeMinter1).bridgeMint(user1.address, mintAmount)
+      )
+        .to.emit(contractInstance, "MintBridge")
+        .withArgs(bridgeMinter1.address, user1.address, mintAmount)
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(addressZero, user1.address, mintAmount);
+
+      const currentLimit = await contractInstance.bridgeMinterAllowance(bridgeMinter1.address);
+      expect(currentLimit).to.equal(DAILY_MINT_LIMIT - mintAmount);
+    });
+
+    it("Should fail to bridge mint when not configured", async function () {
+      const mintAmount = ethers.parseUnits("100000", 6);
+
+      await expect(
+        contractInstance.connect(randomAddress).bridgeMint(user1.address, mintAmount)
+      ).to.be.reverted;
+    });
+
+    it("Should fail to bridge mint exceeding daily limit", async function () {
+      // Remove and re-configure bridge minter with fresh limits for this test
+      await contractInstance.connect(masterMinter).removeBridgeMinter(bridgeMinter1.address);
+      await contractInstance.connect(masterMinter).configureBridgeMinter(bridgeMinter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+      
+      // Use up most of the daily limit with multiple transactions to stay under per-tx cap
+      // Mint 500k twice to use 1M out of daily limit, leaving very little
+      await contractInstance.connect(bridgeMinter1).bridgeMint(user1.address, PER_TX_CAP);
+      await contractInstance.connect(bridgeMinter1).bridgeMint(user1.address, PER_TX_CAP);
+      
+      // Now we should have used about 1M, check remaining
+      const remainingLimit = await contractInstance.bridgeMinterAllowance(bridgeMinter1.address);
+      
+      // Try to mint more than what's left (should be ~100k or less remaining)
+      const exceedingAmount = remainingLimit + ethers.parseUnits("10000", 6);
+
+      await expect(
+        contractInstance.connect(bridgeMinter1).bridgeMint(user1.address, exceedingAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "InsufficientMinterAllowance");
+    });
+
+    it("Should burn tokens via bridge within limits", async function () {
+      const burnAmount = ethers.parseUnits("50000", 6);
+      const balanceBefore = await contractInstance.balanceOf(user1.address);
+
+      await expect(
+        contractInstance.connect(bridgeMinter1).bridgeBurn(user1.address, burnAmount)
+      )
+        .to.emit(contractInstance, "BurnBridge")
+        .withArgs(bridgeMinter1.address, user1.address, burnAmount)
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(user1.address, addressZero, burnAmount);
+
+      expect(await contractInstance.balanceOf(user1.address)).to.equal(balanceBefore - burnAmount);
+    });
+
+    it("Should mint batch via bridge successfully", async function () {
+      // Reset bridge minter limits for this test
+      await contractInstance.connect(masterMinter).removeBridgeMinter(bridgeMinter1.address);
+      await contractInstance.connect(masterMinter).configureBridgeMinter(bridgeMinter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+      
+      const amounts = [
+        ethers.parseUnits("10000", 6),
+        ethers.parseUnits("20000", 6),
+      ];
+      const addresses = [user1.address, user2.address];
+
+      await expect(
+        contractInstance.connect(bridgeMinter1).bridgeMintBatch(addresses, amounts)
+      )
+        .to.emit(contractInstance, "MintBridge")
+        .withArgs(bridgeMinter1.address, user1.address, amounts[0]);
+    });
+  });
+
+  describe("Rate Limit Replenishment", function () {
+    before(async function () {
+      // Configure minter2 with fresh limits
+      await contractInstance
+        .connect(masterMinter)
+        .configureMinter(minter2.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+    });
+
+    it("Should replenish limits over time", async function () {
+      const mintAmount = ethers.parseUnits("500000", 6);
+      
+      // Use half the daily limit
+      await contractInstance.connect(minter2).mint(user1.address, mintAmount);
+      
+      const limitAfterMint = await contractInstance.mintingCurrentLimitOf(minter2.address, false);
+      expect(limitAfterMint).to.equal(DAILY_MINT_LIMIT - mintAmount);
+
+      // Fast forward 12 hours (half a day)
+      await time.increase(12 * 60 * 60);
+
+      // Check limit has replenished
+      const limitAfterTime = await contractInstance.mintingCurrentLimitOf(minter2.address, false);
+      expect(limitAfterTime).to.be.gt(limitAfterMint);
+      
+      // The rate is DAILY_MINT_LIMIT / 86400 per second
+      // After 12 hours (43200 seconds), we should have replenished: (DAILY_MINT_LIMIT / 86400) * 43200 = DAILY_MINT_LIMIT / 2
+      // So the limit should be: (DAILY_MINT_LIMIT - mintAmount) + (DAILY_MINT_LIMIT / 2)
+      // Which simplifies to: DAILY_MINT_LIMIT - mintAmount / 2
+      const expectedLimit = limitAfterMint + (DAILY_MINT_LIMIT / 2n);
+      
+      // Allow for some rounding tolerance
+      expect(limitAfterTime).to.be.closeTo(expectedLimit, ethers.parseUnits("1000", 6));
+    });
+
+    it("Should fully replenish after 24 hours", async function () {
+      const mintAmount = ethers.parseUnits("300000", 6);
+      
+      await contractInstance.connect(minter2).mint(user1.address, mintAmount);
+      
+      // Fast forward 24 hours
+      await time.increase(24 * 60 * 60);
+
+      const limitAfterDay = await contractInstance.mintingCurrentLimitOf(minter2.address, false);
+      expect(limitAfterDay).to.equal(DAILY_MINT_LIMIT);
+    });
+
+    it("Should not exceed max limit even after long time", async function () {
+      // Fast forward 48 hours
+      await time.increase(48 * 60 * 60);
+
+      const limit = await contractInstance.mintingCurrentLimitOf(minter2.address, false);
+      expect(limit).to.equal(DAILY_MINT_LIMIT);
+    });
+  });
+
+  describe("Multiple Minters Independence", function () {
+    before(async function () {
+      // Configure both minters
+      await contractInstance
+        .connect(masterMinter)
+        .configureMinter(minter1.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+      await contractInstance
+        .connect(masterMinter)
+        .configureBridgeMinter(bridgeMinter2.address, DAILY_MINT_LIMIT / 2n, DAILY_BURN_LIMIT / 2n);
+    });
+
+    it("Should have independent limits for different minters", async function () {
+      const mintAmount1 = ethers.parseUnits("400000", 6);
+      const mintAmount2 = ethers.parseUnits("200000", 6);
+
+      // Minter1 mints
+      await contractInstance.connect(minter1).mint(user1.address, mintAmount1);
+      const limit1 = await contractInstance.minterAllowance(minter1.address);
+
+      // BridgeMinter2 mints (different minter type)
+      await contractInstance.connect(bridgeMinter2).bridgeMint(user2.address, mintAmount2);
+      const limit2 = await contractInstance.bridgeMinterAllowance(bridgeMinter2.address);
+
+      // Check limits are independent
+      expect(limit1).to.equal(DAILY_MINT_LIMIT - mintAmount1);
+      expect(limit2).to.equal(DAILY_MINT_LIMIT / 2n - mintAmount2);
+    });
+  });
+
+  describe("View Functions", function () {
+    it("Should return correct max limits", async function () {
+      const mintLimit = await contractInstance.mintingMaxLimitOf(minter1.address, false);
+      const burnLimit = await contractInstance.burningMaxLimitOf(minter1.address, false);
+
+      expect(mintLimit).to.equal(DAILY_MINT_LIMIT);
+      expect(burnLimit).to.equal(DAILY_BURN_LIMIT);
+    });
+
+    it("Should return correct current limits", async function () {
+      const currentMintLimit = await contractInstance.mintingCurrentLimitOf(minter1.address, false);
+      const currentBurnLimit = await contractInstance.burningCurrentLimitOf(minter1.address, false);
+
+      expect(currentMintLimit).to.be.lte(DAILY_MINT_LIMIT);
+      expect(currentBurnLimit).to.be.lte(DAILY_BURN_LIMIT);
+    });
+
+    it("Should correctly identify minters", async function () {
+      expect(await contractInstance.isMinter(minter1.address)).to.be.true;
+      expect(await contractInstance.isMinter(randomAddress.address)).to.be.false;
+      // bridgeMinter1 was re-configured in "Bridge Minter Operations" section, so should be true
+      expect(await contractInstance.isBridgeMinter(bridgeMinter1.address)).to.be.true;
+      expect(await contractInstance.isBridgeMinter(bridgeMinter2.address)).to.be.true;
+    });
+  });
+
+  describe("Minimum Limit Validation", function () {
+    it("Should revert when configuring minter with mint limit below minimum", async function () {
+      // _MIN_LIMIT is 86400 in raw units (not with decimals)
+      // So we need a value less than 86400, like 50000 raw units
+      const belowMinLimit = 50000; // Less than _MIN_LIMIT (86400) in raw units
+      
+      await expect(
+        contractInstance.connect(masterMinter).configureMinter(
+          user1.address, // Use a different address
+          belowMinLimit,
+          DAILY_BURN_LIMIT
+        )
+      ).to.be.revertedWithCustomError(contractInstance, "LimitTooLow");
+    });
+
+    it("Should revert when configuring minter with burn limit below minimum", async function () {
+      const belowMinLimit = 50000; // Less than _MIN_LIMIT (86400) in raw units
+      
+      await expect(
+        contractInstance.connect(masterMinter).configureMinter(
+          user2.address, // Use a different address
+          DAILY_MINT_LIMIT,
+          belowMinLimit
+        )
+      ).to.be.revertedWithCustomError(contractInstance, "LimitTooLow");
+    });
+
+    it("Should revert when configuring bridge minter with limit below minimum", async function () {
+      const belowMinLimit = 50000; // Less than _MIN_LIMIT (86400) in raw units
+      
+      await expect(
+        contractInstance.connect(masterMinter).configureBridgeMinter(
+          user1.address, // Use a different address
+          belowMinLimit,
+          DAILY_BURN_LIMIT
+        )
+      ).to.be.revertedWithCustomError(contractInstance, "LimitTooLow");
+    });
+
+    it("Should accept limit at exactly the minimum threshold", async function () {
+      const minLimit = 86400; // Exactly _MIN_LIMIT in raw units
+      
+      await expect(
+        contractInstance.connect(masterMinter).configureMinter(
+          user2.address, // Use a different address that's not already configured
+          minLimit,
+          minLimit
+        )
+      ).to.emit(contractInstance, "MinterConfigured");
+      
+      // Cleanup
+      await contractInstance.connect(masterMinter).removeMinter(user2.address);
+    });
+  });
+
+  describe("Custom Error Tests", function () {
+    it("Should revert with AccountAlreadyMinter when bridge account has MINTER role", async function () {
+      // First configure as minter
+      await contractInstance.connect(masterMinter).configureMinter(
+        randomAddress.address,
+        DAILY_MINT_LIMIT,
+        DAILY_BURN_LIMIT
+      );
+      
+      // Try to configure same address as bridge minter
+      await expect(
+        contractInstance.connect(masterMinter).configureBridgeMinter(
+          randomAddress.address,
+          DAILY_MINT_LIMIT,
+          DAILY_BURN_LIMIT
+        )
+      ).to.be.revertedWithCustomError(contractInstance, "AccountAlreadyMinter");
+      
+      // Cleanup
+      await contractInstance.connect(masterMinter).removeMinter(randomAddress.address);
+    });
+
+    it("Should revert with AccountAlreadyBridgeMinter when minter account has BRIDGE_MINTER role", async function () {
+      // First configure as bridge minter
+      await contractInstance.connect(masterMinter).configureBridgeMinter(
+        randomAddress.address,
+        DAILY_MINT_LIMIT,
+        DAILY_BURN_LIMIT
+      );
+      
+      // Try to configure same address as minter
+      await expect(
+        contractInstance.connect(masterMinter).configureMinter(
+          randomAddress.address,
+          DAILY_MINT_LIMIT,
+          DAILY_BURN_LIMIT
+        )
+      ).to.be.revertedWithCustomError(contractInstance, "AccountAlreadyBridgeMinter");
+      
+      // Cleanup
+      await contractInstance.connect(masterMinter).removeBridgeMinter(randomAddress.address);
+    });
+  });
+
+  describe("Limit Update Event", function () {
+    it("Should emit MinterLimitsUpdated when updating existing minter", async function () {
+      // First configure minter
+      await contractInstance.connect(masterMinter).configureMinter(
+        randomAddress.address,
+        DAILY_MINT_LIMIT,
+        DAILY_BURN_LIMIT
+      );
+      
+      const newMintLimit = ethers.parseUnits("2000000", 6);
+      const newBurnLimit = ethers.parseUnits("2000000", 6);
+      
+      // Update limits
+      await expect(
+        contractInstance.connect(masterMinter).configureMinter(
+          randomAddress.address,
+          newMintLimit,
+          newBurnLimit
+        )
+      ).to.emit(contractInstance, "MinterLimitsUpdated")
+        .withArgs(randomAddress.address, newMintLimit, newBurnLimit, false);
+      
+      // Cleanup
+      await contractInstance.connect(masterMinter).removeMinter(randomAddress.address);
+    });
+
+    it("Should emit BridgeMinterConfigured for new bridge minter, not update event", async function () {
+      await expect(
+        contractInstance.connect(masterMinter).configureBridgeMinter(
+          randomAddress.address,
+          DAILY_MINT_LIMIT,
+          DAILY_BURN_LIMIT
+        )
+      ).to.emit(contractInstance, "BridgeMinterConfigured")
+        .withArgs(randomAddress.address, DAILY_MINT_LIMIT, DAILY_BURN_LIMIT);
+      
+      // Cleanup
+      await contractInstance.connect(masterMinter).removeBridgeMinter(randomAddress.address);
+    });
+  });
+
+  describe("Destroy Blacklisted Funds", function () {
+    it("Should destroy blacklisted funds by master minter", async function () {
+      const mintAmount = ethers.parseUnits("100000", 6);
+      
+      // Mint to user
+      await contractInstance.connect(minter1).mint(user2.address, mintAmount);
+      
+      // Blacklist user
+      await contractInstance.connect(blacklister).blacklist(user2.address);
+      
+      const balanceBefore = await contractInstance.balanceOf(user2.address);
+      
+      await expect(
+        contractInstance.connect(masterMinter).destroyBlacklistedFunds(user2.address)
+      )
+        .to.emit(contractInstance, "BurnNative")
+        .withArgs(masterMinter.address, user2.address, balanceBefore);
+
+      expect(await contractInstance.balanceOf(user2.address)).to.equal(0);
+      
+      await contractInstance.connect(blacklister).unblacklist(user2.address);
+    });
+
+    it("Should fail to destroy funds of non-blacklisted address", async function () {
+      await expect(
+        contractInstance.connect(masterMinter).destroyBlacklistedFunds(user1.address)
+      ).to.be.revertedWithCustomError(contractInstance, "SenderNotBlacklisted");
+    });
+  });
+});

--- a/test/supply.ts
+++ b/test/supply.ts
@@ -7,7 +7,8 @@ describe("Minting,  Burning And Token Rescue", function () {
   let contractInstance: Stablecoin;
   let defaultAdmin: SignerWithAddress;
   let freezer: SignerWithAddress;
-  let supplyController: SignerWithAddress;
+  let masterMinter: SignerWithAddress;
+  let minter: SignerWithAddress;
   let upgrader: SignerWithAddress;
   let reserve1: SignerWithAddress;
   let reserve2: SignerWithAddress;
@@ -17,12 +18,14 @@ describe("Minting,  Burning And Token Rescue", function () {
   let recoverAddress: SignerWithAddress;
   let randomAddress: SignerWithAddress;
   const addressZero = "0x0000000000000000000000000000000000000000";
+  const DAILY_LIMIT = ethers.parseUnits("10000000", 6); // 10M tokens daily limit
 
   before(async function () {
     [
       defaultAdmin,
       freezer,
-      supplyController,
+      masterMinter,
+      minter,
       upgrader,
       blacklister,
       reserve1,
@@ -43,7 +46,7 @@ describe("Minting,  Burning And Token Rescue", function () {
         defaultAdmin.address,
         defaultAdminDelay,
         freezer.address,
-        supplyController.address,
+        masterMinter.address,
         upgrader.address,
         blacklister.address,
         rescuer.address,
@@ -52,6 +55,9 @@ describe("Minting,  Burning And Token Rescue", function () {
       { kind: "uups" }
     );
     contractInstance = (await contract.waitForDeployment()) as unknown as Stablecoin;
+    
+    // Configure minter with high limits for testing
+    await contractInstance.connect(masterMinter).configureMinter(minter.address, DAILY_LIMIT, DAILY_LIMIT);
   });
 
   it("Should have 0 total supply on init and unpaused", async function () {
@@ -63,17 +69,17 @@ describe("Minting,  Burning And Token Rescue", function () {
 
   it("Should fail to mint tokens exceeding max mint limit", async function () {
     // Set mint amount greater than the maxMintLimit
-    const mintAmount = ethers.parseUnits("2000000", 18); // 2 million tokens (assuming maxMintLimit is 1 million)
+    const mintAmount = ethers.parseUnits("2000000", 6); // 2 million tokens (exceeds 1M per-tx cap)
 
     await expect(
       contractInstance
-        .connect(supplyController)
+        .connect(minter)
         .mint(randomAddress.address, mintAmount)
-    ).to.be.revertedWithCustomError(contractInstance, "ExceedsMintTransactionCap()");
+    ).to.be.revertedWithCustomError(contractInstance, "ExceedsMintTransactionCap");
   });
 
   it("Should update the max mint limit successfully through setter function", async function () {
-    const newPerTransactionCap = ethers.parseUnits("2000000", 18); // 2 million tokens
+    const newPerTransactionCap = ethers.parseUnits("2000000", 6); // 2 million tokens
 
     // Update the max mint limit using the setter function
     await expect(contractInstance
@@ -87,41 +93,41 @@ describe("Minting,  Burning And Token Rescue", function () {
     expect(currentMaxMintLimit).to.equal(newPerTransactionCap);
 
     // Attempt to mint exceeding the updated limit and expect it to fail
-    const exceedingMintAmount = ethers.parseUnits("2500000", 18); // 2.5 million tokens
+    const exceedingMintAmount = ethers.parseUnits("2500000", 6); // 2.5 million tokens
     await expect(
-      contractInstance.connect(supplyController).mint(randomAddress.address, exceedingMintAmount)
-    ).to.be.revertedWithCustomError(contractInstance, "ExceedsMintTransactionCap()");
+      contractInstance.connect(minter).mint(randomAddress.address, exceedingMintAmount)
+    ).to.be.revertedWithCustomError(contractInstance, "ExceedsMintTransactionCap");
   });
 
   it("Should fail to update the max mint limit to zero", async function () {
-    const zeroCap = ethers.parseUnits("0", 18); // Zero tokens
+    const zeroCap = ethers.parseUnits("0", 6); // Zero tokens
 
     // Attempt to update the max mint limit to zero and expect it to fail
     await expect(
       contractInstance.connect(defaultAdmin).setMintCapPerTransaction(zeroCap)
-    ).to.be.revertedWithCustomError(contractInstance, "InvalidAmount()");
+    ).to.be.revertedWithCustomError(contractInstance, "InvalidAmount");
   });
 
   it("Should mint tokens successfully to any external address", async function () {
-    const mintAmount = ethers.parseUnits("1000", 18);
+    const mintAmount = ethers.parseUnits("1000", 6);
     await expect(
       contractInstance
-        .connect(supplyController)
+        .connect(minter)
         .mint(randomAddress.address, mintAmount)
     )
       .to.emit(contractInstance, "Transfer")
       .withArgs(addressZero, randomAddress.address, mintAmount)
-      .to.emit(contractInstance, "Mint")
-      .withArgs(randomAddress.address, mintAmount);
+      .to.emit(contractInstance, "MintNative")
+      .withArgs(minter.address, randomAddress.address, mintAmount);
     const balance = await contractInstance.balanceOf(randomAddress.address);
     expect(balance).to.equal(mintAmount);
     expect(await contractInstance.totalSupply()).to.equal(mintAmount);
   });
 
   it("Should be able to recover tokens stuck in contract address", async function () {
-    const transferAmount = ethers.parseUnits("1000", 18);
+    const transferAmount = ethers.parseUnits("1000", 6);
     await contractInstance
-      .connect(supplyController)
+      .connect(minter)
       .mint(reserve3.address, transferAmount);
     const balanceAfterTransfer = await contractInstance.balanceOf(
       reserve3.address
@@ -159,7 +165,7 @@ describe("Minting,  Burning And Token Rescue", function () {
     const newTokenContractBalance = await contractInstance.balanceOf(
       contractInstance.getAddress()
     );
-    expect(newTokenContractBalance).to.equal(ethers.parseUnits("0", 18));
+    expect(newTokenContractBalance).to.equal(ethers.parseUnits("0", 6));
     const balanceAtRecoverAddress = await contractInstance.balanceOf(
       recoverAddress.address
     );
@@ -167,7 +173,7 @@ describe("Minting,  Burning And Token Rescue", function () {
   });
   
   it("Should fail to rescue tokens when called by unauthorized address", async function() {
-    const transferAmount = ethers.parseUnits("1000", 18);
+    const transferAmount = ethers.parseUnits("1000", 6);
   
     await expect(
       contractInstance.connect(randomAddress).rescueTokens(
@@ -179,7 +185,7 @@ describe("Minting,  Burning And Token Rescue", function () {
   });
   
   it("Should fail to rescue tokens to address zero", async function() {
-    const transferAmount = ethers.parseUnits("1000", 18);
+    const transferAmount = ethers.parseUnits("1000", 6);
   
     await expect(
       contractInstance.connect(rescuer).rescueTokens(
@@ -187,7 +193,7 @@ describe("Minting,  Burning And Token Rescue", function () {
         addressZero,
         transferAmount
       )
-    ).to.be.revertedWithCustomError(contractInstance, "InvalidAddress()");
+    ).to.be.revertedWithCustomError(contractInstance, "InvalidAddress");
   });
   
   it("Should fail to rescue zero tokens", async function() {
@@ -201,23 +207,23 @@ describe("Minting,  Burning And Token Rescue", function () {
   });
   
   it("Should fail to rescue tokens to blacklisted address", async function() {
-    const transferAmount = ethers.parseUnits("1000", 18);
+    const transferAmount = ethers.parseUnits("1000", 6);
     
     // Blacklist the recipient address
-    await contractInstance.connect(blacklister).blacklist(recoverAddress.address);
+    await contractInstance.connect(blacklister).blacklist(reserve2.address);
   
     await expect(
       contractInstance.connect(rescuer).rescueTokens(
         contractInstance.getAddress(),
-        recoverAddress.address,
+        reserve2.address,
         transferAmount
       )
     ).to.be.revertedWithCustomError(contractInstance, "RecipientBlacklisted");
-    await contractInstance.connect(blacklister).unblacklist(recoverAddress.address);
+    await contractInstance.connect(blacklister).unblacklist(reserve2.address);
   });
 
   it("Should fail to mint tokens when called by unauthorized address", async function () {
-    const mintAmount = ethers.parseUnits("1000", 18);
+    const mintAmount = ethers.parseUnits("1000", 6);
     let failed = false;
     try {
       // Attempt to mint tokens by an unauthorized signer (e.g., defaultAdmin)
@@ -232,21 +238,21 @@ describe("Minting,  Burning And Token Rescue", function () {
   });
 
   it("Should burn tokens successfully from an address", async function () {
-    const burnAmount = ethers.parseUnits("500", 18);
+    const burnAmount = ethers.parseUnits("500", 6);
     await contractInstance
-      .connect(supplyController)
+      .connect(minter)
       .mint(reserve1.address, burnAmount);
     const totalSupply = await contractInstance.totalSupply();
     const initialBalance = await contractInstance.balanceOf(reserve1.address);
     await expect(
       contractInstance
-        .connect(supplyController)
+        .connect(minter)
         .burn(reserve1.address, burnAmount)
     )
       .to.emit(contractInstance, "Transfer")
       .withArgs(reserve1.address, addressZero, burnAmount)
-      .to.emit(contractInstance, "Burn")
-      .withArgs(reserve1.address, burnAmount);
+      .to.emit(contractInstance, "BurnNative")
+      .withArgs(minter.address, reserve1.address, burnAmount);
     const finalBalance = await contractInstance.balanceOf(reserve1.address);
     expect(finalBalance).to.equal(initialBalance - burnAmount);
     expect(await contractInstance.totalSupply()).to.equal(
@@ -255,7 +261,7 @@ describe("Minting,  Burning And Token Rescue", function () {
   });
 
   it("Should fail to burn tokens when called by unauthorized address", async function () {
-    const burnAmount = ethers.parseUnits("500", 18);
+    const burnAmount = ethers.parseUnits("500", 6);
     let failed = false;
     try {
       // Attempt to burn tokens by an unauthorized signer (e.g., defaultAdmin)
@@ -270,7 +276,7 @@ describe("Minting,  Burning And Token Rescue", function () {
   });
 
   it("Should mint tokens successfully in batch to multiple external addresses", async function () {
-    const mintAmount = ethers.parseUnits("1000", 18);
+    const mintAmount = ethers.parseUnits("1000", 6);
     const addresses = [
       "0x32FdfD2eA08d916B8f4e73d057E99bc3358b2F4D",
       "0xECc966AB425F3F5Bd58085ce4eBDBf81D829126F",
@@ -279,16 +285,16 @@ describe("Minting,  Burning And Token Rescue", function () {
     const amounts = [mintAmount, mintAmount * 2n, mintAmount * 3n];
 
     await expect(
-      contractInstance.connect(supplyController).mintBatch(addresses, amounts)
+      contractInstance.connect(minter).mintBatch(addresses, amounts)
     )
       .to.emit(contractInstance, "Transfer")
       .withArgs(addressZero, addresses[0], mintAmount)
-      .to.emit(contractInstance, "Mint")
-      .withArgs(addresses[0], mintAmount)
+      .to.emit(contractInstance, "MintNative")
+      .withArgs(minter.address, addresses[0], mintAmount)
       .to.emit(contractInstance, "Transfer")
       .withArgs(addressZero, addresses[1], mintAmount * 2n)
-      .to.emit(contractInstance, "Mint")
-      .withArgs(addresses[1], mintAmount * 2n)
+      .to.emit(contractInstance, "MintNative")
+      .withArgs(minter.address, addresses[1], mintAmount * 2n)
       .to.emit(contractInstance, "Transfer")
       .withArgs(addressZero, addresses[2], mintAmount * 3n);
 
@@ -299,7 +305,7 @@ describe("Minting,  Burning And Token Rescue", function () {
   });
 
   it("Should fail to mint tokens in batch when called by unauthorized address", async function () {
-    const mintAmount = ethers.parseUnits("1000", 18);
+    const mintAmount = ethers.parseUnits("1000", 6);
     const addresses = [reserve1.address, reserve2.address, reserve3.address];
     const amounts = [mintAmount, mintAmount, mintAmount];
     let failed = false;
@@ -318,7 +324,7 @@ describe("Minting,  Burning And Token Rescue", function () {
   });
 
   it("Should fail to mint tokens if address array and amount array length doesn't match", async function () {
-    const mintAmount = ethers.parseUnits("1000", 18);
+    const mintAmount = ethers.parseUnits("1000", 6);
     const addresses = [reserve1.address, reserve2.address];
     const amounts = [mintAmount, mintAmount, mintAmount];
     let failed = false;
@@ -326,7 +332,7 @@ describe("Minting,  Burning And Token Rescue", function () {
     try {
       // Attempt to mint tokens when address array and amount array length doesn't match
       await contractInstance
-        .connect(supplyController)
+        .connect(minter)
         .mintBatch(addresses, amounts);
     } catch (error) {
       failed = true;


### PR DESCRIPTION
Add rate limiting mechanism to control the velocity of minting and burning operations to enhance security and prevent abuse. This implementation:

- Adds configurable rate limits to the Stablecoin contract
- Introduces rate tracking for mint/burn transactions
- Adds validation to prevent operations exceeding defined limits
- Includes comprehensive test suite in rate-limiting.ts
- Updates existing tests to account for rate limiting behavior

Ticket: SCAAS-1015