### PR TITLE
fix: BGO-1 Minters  Burn Tokens without approval

### DIFF
--- a/contracts/Stablecoin.sol
+++ b/contracts/Stablecoin.sol
@@ -539,6 +539,11 @@ contract Stablecoin is
     function _burnTokens(address from, uint256 amount, bool isBridge) internal {
         if (isBlacklisted(from)) revert SenderBlacklisted();
         
+        // Check allowance if burning from another address
+        if (from != msg.sender) {
+            _spendAllowance(from, msg.sender, amount);
+        }
+        
         MinterConfig storage config = _getMinterConfig(msg.sender, isBridge);
         _validateMinterConfigured(config, isBridge);
         

--- a/test/pause.ts
+++ b/test/pause.ts
@@ -94,9 +94,17 @@ describe("pause", function () {
   it("Should fail to burn tokens when the token is paused", async function () {
     const burnAmount = ethers.parseUnits("500", 6);
 
+    // First unpause to mint tokens to minter
+    await contractInstance.connect(freezer).unpause();
+    await contractInstance.connect(minter).mint(minter.address, burnAmount);
+    
+    // Now pause again
+    await contractInstance.connect(freezer).pause();
+
     let failed = false;
     try {
-      await contractInstance.connect(minter).burn(reserve1.address, burnAmount);
+      // Minter tries to burn their own tokens while paused
+      await contractInstance.connect(minter).burn(minter.address, burnAmount);
     } catch (error) {
       failed = true;
       expect((error as Error).message).equal(

--- a/test/rate-limiting.ts
+++ b/test/rate-limiting.ts
@@ -249,6 +249,9 @@ describe("Rate Limiting - Master Minter, Minter, and Bridge Minter", function ()
       const burnAmount = ethers.parseUnits("50000", 6);
       const balanceBefore = await contractInstance.balanceOf(user1.address);
 
+      // User1 must approve minter1 to burn their tokens
+      await contractInstance.connect(user1).approve(minter1.address, burnAmount);
+
       await expect(
         contractInstance.connect(minter1).burn(user1.address, burnAmount)
       )
@@ -269,12 +272,17 @@ describe("Rate Limiting - Master Minter, Minter, and Bridge Minter", function ()
       const amountToBurn = currentBurnLimit - ethers.parseUnits("1000", 6);
       
       if (amountToBurn > 0n && amountToBurn <= user1Balance) {
+        // User1 approves minter1 to burn tokens
+        await contractInstance.connect(user1).approve(minter1.address, amountToBurn);
         await contractInstance.connect(minter1).burn(user1.address, amountToBurn);
       }
       
       // Now try to burn more than what's left in the daily limit
       const remainingLimit = await contractInstance.burningCurrentLimitOf(minter1.address, false);
       const exceedingAmount = remainingLimit + ethers.parseUnits("1000", 6);
+
+      // User1 approves the exceeding amount
+      await contractInstance.connect(user1).approve(minter1.address, exceedingAmount);
 
       await expect(
         contractInstance.connect(minter1).burn(user1.address, exceedingAmount)
@@ -367,6 +375,9 @@ describe("Rate Limiting - Master Minter, Minter, and Bridge Minter", function ()
     it("Should burn tokens via bridge within limits", async function () {
       const burnAmount = ethers.parseUnits("50000", 6);
       const balanceBefore = await contractInstance.balanceOf(user1.address);
+
+      // User1 must approve bridgeMinter1 to burn their tokens
+      await contractInstance.connect(user1).approve(bridgeMinter1.address, burnAmount);
 
       await expect(
         contractInstance.connect(bridgeMinter1).bridgeBurn(user1.address, burnAmount)
@@ -701,6 +712,9 @@ describe("Rate Limiting - Master Minter, Minter, and Bridge Minter", function ()
       const burnAmount = ethers.parseUnits("300000", 6);
       
       await contractInstance.connect(testMinter).mint(user1.address, mintAmount);
+      
+      // User1 must approve testMinter to burn their tokens
+      await contractInstance.connect(user1).approve(testMinter.address, burnAmount);
       await contractInstance.connect(testMinter).burn(user1.address, burnAmount);
       
       // Verify limits are reduced
@@ -731,6 +745,9 @@ describe("Rate Limiting - Master Minter, Minter, and Bridge Minter", function ()
       const burnAmount = ethers.parseUnits("250000", 6);
       
       await contractInstance.connect(testBridgeMinter).bridgeMint(user1.address, mintAmount);
+      
+      // User1 must approve testBridgeMinter to burn their tokens
+      await contractInstance.connect(user1).approve(testBridgeMinter.address, burnAmount);
       await contractInstance.connect(testBridgeMinter).bridgeBurn(user1.address, burnAmount);
       
       // Verify limits are reduced
@@ -778,6 +795,9 @@ describe("Rate Limiting - Master Minter, Minter, and Bridge Minter", function ()
     it("Should replenish both mint and burn limits simultaneously", async function () {
       // Drain both limits significantly
       await contractInstance.connect(testMinter).mint(user1.address, PER_TX_CAP);
+      
+      // User1 must approve testMinter to burn their tokens
+      await contractInstance.connect(user1).approve(testMinter.address, PER_TX_CAP);
       await contractInstance.connect(testMinter).burn(user1.address, PER_TX_CAP);
       
       const mintLimitBefore = await contractInstance.mintingCurrentLimitOf(testMinter.address, false);

--- a/test/supply-validator.ts
+++ b/test/supply-validator.ts
@@ -241,6 +241,9 @@ describe("Supply Validator", function () {
     it("Should call validator on native burn operations", async function () {
       const burnAmount = ethers.parseUnits("1000", 6);
       
+      // Recipient must approve minter to burn their tokens
+      await contractInstance.connect(recipient).approve(minter.address, burnAmount);
+      
       await contractInstance.connect(minter).burn(recipient.address, burnAmount);
       
       expect(await mockValidator.burnCallCount()).to.equal(1);
@@ -253,6 +256,9 @@ describe("Supply Validator", function () {
     it("Should pass correct parameters to validator for native burn", async function () {
       const burnAmount = ethers.parseUnits("2000", 6);
       
+      // Recipient must approve minter to burn their tokens
+      await contractInstance.connect(recipient).approve(minter.address, burnAmount);
+      
       await contractInstance.connect(minter).burn(recipient.address, burnAmount);
       
       expect(await mockValidator.lastBurnAccount()).to.equal(recipient.address);
@@ -263,6 +269,9 @@ describe("Supply Validator", function () {
 
     it("Should revert burn if validator reverts", async function () {
       const burnAmount = ethers.parseUnits("1000", 6);
+      
+      // Recipient must approve minter to burn their tokens
+      await contractInstance.connect(recipient).approve(minter.address, burnAmount);
       
       // Configure validator to reject burns
       await mockValidator.setRejectBurn(true);
@@ -275,6 +284,9 @@ describe("Supply Validator", function () {
     it("Should allow burn when validator accepts", async function () {
       const burnAmount = ethers.parseUnits("1000", 6);
       const initialBalance = await contractInstance.balanceOf(recipient.address);
+      
+      // Recipient must approve minter to burn their tokens
+      await contractInstance.connect(recipient).approve(minter.address, burnAmount);
       
       await expect(
         contractInstance.connect(minter).burn(recipient.address, burnAmount)
@@ -298,6 +310,9 @@ describe("Supply Validator", function () {
     it("Should call validator on bridge burn operations", async function () {
       const burnAmount = ethers.parseUnits("1500", 6);
       
+      // Recipient must approve bridgeMinter to burn their tokens
+      await contractInstance.connect(recipient).approve(bridgeMinter.address, burnAmount);
+      
       await contractInstance.connect(bridgeMinter).bridgeBurn(recipient.address, burnAmount);
       
       expect(await mockValidator.burnCallCount()).to.equal(1);
@@ -310,6 +325,9 @@ describe("Supply Validator", function () {
     it("Should pass correct parameters to validator for bridge burn", async function () {
       const burnAmount = ethers.parseUnits("2500", 6);
       
+      // Recipient must approve bridgeMinter to burn their tokens
+      await contractInstance.connect(recipient).approve(bridgeMinter.address, burnAmount);
+      
       await contractInstance.connect(bridgeMinter).bridgeBurn(recipient.address, burnAmount);
       
       expect(await mockValidator.lastBurnAccount()).to.equal(recipient.address);
@@ -320,6 +338,9 @@ describe("Supply Validator", function () {
 
     it("Should revert bridge burn if validator reverts", async function () {
       const burnAmount = ethers.parseUnits("1500", 6);
+      
+      // Recipient must approve bridgeMinter to burn their tokens
+      await contractInstance.connect(recipient).approve(bridgeMinter.address, burnAmount);
       
       // Configure validator to reject burns
       await mockValidator.setRejectBurn(true);
@@ -358,6 +379,9 @@ describe("Supply Validator", function () {
       // Mint first
       await contractInstance.connect(minter).mint(recipient.address, mintAmount);
       
+      // Recipient must approve minter to burn their tokens
+      await contractInstance.connect(recipient).approve(minter.address, burnAmount);
+      
       // Burn without validator
       await contractInstance.connect(minter).burn(recipient.address, burnAmount);
       
@@ -371,6 +395,9 @@ describe("Supply Validator", function () {
       
       // Mint first
       await contractInstance.connect(bridgeMinter).bridgeMint(recipient.address, mintAmount);
+      
+      // Recipient must approve bridgeMinter to burn their tokens
+      await contractInstance.connect(recipient).approve(bridgeMinter.address, burnAmount);
       
       // Burn without validator
       await contractInstance.connect(bridgeMinter).bridgeBurn(recipient.address, burnAmount);
@@ -425,6 +452,9 @@ describe("Supply Validator", function () {
       await contractInstance.connect(minter).mint(recipient.address, mintAmount);
       expect(await mockValidator.mintCallCount()).to.equal(1);
       expect(await mockValidator.burnCallCount()).to.equal(0);
+      
+      // Recipient must approve minter to burn their tokens
+      await contractInstance.connect(recipient).approve(minter.address, burnAmount);
       
       await contractInstance.connect(minter).burn(recipient.address, burnAmount);
       expect(await mockValidator.mintCallCount()).to.equal(1);

--- a/test/supply.ts
+++ b/test/supply.ts
@@ -2,6 +2,7 @@ import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { expect } from "chai";
 import { ethers, upgrades } from "hardhat";
 import { Stablecoin } from "../typechain-types";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
 
 describe("Minting,  Burning And Token Rescue", function () {
   let contractInstance: Stablecoin;
@@ -9,6 +10,7 @@ describe("Minting,  Burning And Token Rescue", function () {
   let freezer: SignerWithAddress;
   let masterMinter: SignerWithAddress;
   let minter: SignerWithAddress;
+  let bridgeMinter: SignerWithAddress;
   let upgrader: SignerWithAddress;
   let reserve1: SignerWithAddress;
   let reserve2: SignerWithAddress;
@@ -17,6 +19,9 @@ describe("Minting,  Burning And Token Rescue", function () {
   let rescuer: SignerWithAddress;
   let recoverAddress: SignerWithAddress;
   let randomAddress: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+  let user3: SignerWithAddress;
   const addressZero = "0x0000000000000000000000000000000000000000";
   const DAILY_LIMIT = ethers.parseUnits("10000000", 6); // 10M tokens daily limit
 
@@ -26,6 +31,7 @@ describe("Minting,  Burning And Token Rescue", function () {
       freezer,
       masterMinter,
       minter,
+      bridgeMinter,
       upgrader,
       blacklister,
       reserve1,
@@ -34,6 +40,9 @@ describe("Minting,  Burning And Token Rescue", function () {
       rescuer,
       recoverAddress,
       randomAddress,
+      user1,
+      user2,
+      user3,
     ] = await ethers.getSigners();
     const ContractFactory = await ethers.getContractFactory("Stablecoin");
     const defaultAdminDelay = 7 * 24 * 60 * 60; // 7 days in seconds (or any appropriate value)
@@ -58,6 +67,9 @@ describe("Minting,  Burning And Token Rescue", function () {
     
     // Configure minter with high limits for testing
     await contractInstance.connect(masterMinter).configureMinter(minter.address, DAILY_LIMIT, DAILY_LIMIT);
+    
+    // Configure bridge minter with high limits for testing
+    await contractInstance.connect(masterMinter).configureBridgeMinter(bridgeMinter.address, DAILY_LIMIT, DAILY_LIMIT);
   });
 
   it("Should have 0 total supply on init and unpaused", async function () {
@@ -244,6 +256,10 @@ describe("Minting,  Burning And Token Rescue", function () {
       .mint(reserve1.address, burnAmount);
     const totalSupply = await contractInstance.totalSupply();
     const initialBalance = await contractInstance.balanceOf(reserve1.address);
+    
+    // Reserve1 must approve minter to burn their tokens
+    await contractInstance.connect(reserve1).approve(minter.address, burnAmount);
+    
     await expect(
       contractInstance
         .connect(minter)
@@ -343,5 +359,465 @@ describe("Minting,  Burning And Token Rescue", function () {
     }
 
     expect(failed).to.be.true;
+  });
+
+  describe("Native Burn Authorization Tests", function () {
+    it("Should allow minter to burn their own tokens without approval", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const burnAmount = ethers.parseUnits("500", 6);
+
+      // Mint tokens to the minter
+      const balanceBefore = await contractInstance.balanceOf(minter.address);
+      await contractInstance.connect(minter).mint(minter.address, mintAmount);
+      
+      const balanceAfterMint = await contractInstance.balanceOf(minter.address);
+      expect(balanceAfterMint).to.equal(balanceBefore + mintAmount);
+
+      // Minter should be able to burn their own tokens
+      await expect(
+        contractInstance.connect(minter).burn(minter.address, burnAmount)
+      )
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(minter.address, addressZero, burnAmount)
+        .to.emit(contractInstance, "BurnNative")
+        .withArgs(minter.address, minter.address, burnAmount);
+
+      const balanceAfter = await contractInstance.balanceOf(minter.address);
+      expect(balanceAfter).to.equal(balanceAfterMint - burnAmount);
+    });
+
+    it("Should revert when minter tries to burn from another address without approval", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+
+      // Mint tokens to user1
+      await contractInstance.connect(minter).mint(user1.address, mintAmount);
+
+      // Minter tries to burn from user1 without approval - should fail
+      await expect(
+        contractInstance.connect(minter).burn(user1.address, mintAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "ERC20InsufficientAllowance");
+    });
+
+    it("Should revert when minter tries to burn from another address with insufficient approval", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const approvalAmount = ethers.parseUnits("500", 6);
+
+      // Mint tokens to user1
+      await contractInstance.connect(minter).mint(user1.address, mintAmount);
+
+      // User1 approves minter for only 500 tokens
+      await contractInstance.connect(user1).approve(minter.address, approvalAmount);
+
+      // Minter tries to burn 1000 tokens - should fail
+      await expect(
+        contractInstance.connect(minter).burn(user1.address, mintAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "ERC20InsufficientAllowance");
+    });
+
+    it("Should allow minter to burn from another address with sufficient approval and reduce allowance", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const burnAmount = ethers.parseUnits("500", 6);
+
+      // Get initial balance
+      const balanceBefore = await contractInstance.balanceOf(user1.address);
+
+      // Mint tokens to user1
+      await contractInstance.connect(minter).mint(user1.address, mintAmount);
+
+      // User1 approves minter for 1000 tokens
+      await contractInstance.connect(user1).approve(minter.address, mintAmount);
+
+      const allowanceBefore = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowanceBefore).to.equal(mintAmount);
+
+      // Minter burns 500 tokens from user1
+      await expect(
+        contractInstance.connect(minter).burn(user1.address, burnAmount)
+      )
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(user1.address, addressZero, burnAmount)
+        .to.emit(contractInstance, "BurnNative")
+        .withArgs(minter.address, user1.address, burnAmount);
+
+      const balanceAfter = await contractInstance.balanceOf(user1.address);
+      expect(balanceAfter).to.equal(balanceBefore + mintAmount - burnAmount);
+
+      // Allowance should be reduced by burn amount
+      const allowanceAfter = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowanceAfter).to.equal(mintAmount - burnAmount);
+    });
+
+    it("Should allow minter to burn from another address with infinite approval without reducing allowance", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const burnAmount = ethers.parseUnits("500", 6);
+      const maxUint256 = ethers.MaxUint256;
+
+      // Get initial balance
+      const balanceBefore = await contractInstance.balanceOf(user1.address);
+
+      // Mint tokens to user1
+      await contractInstance.connect(minter).mint(user1.address, mintAmount);
+
+      // User1 approves minter for infinite amount
+      await contractInstance.connect(user1).approve(minter.address, maxUint256);
+
+      const allowanceBefore = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowanceBefore).to.equal(maxUint256);
+
+      // Minter burns 500 tokens from user1
+      await expect(
+        contractInstance.connect(minter).burn(user1.address, burnAmount)
+      )
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(user1.address, addressZero, burnAmount)
+        .to.emit(contractInstance, "BurnNative")
+        .withArgs(minter.address, user1.address, burnAmount);
+
+      const balanceAfter = await contractInstance.balanceOf(user1.address);
+      expect(balanceAfter).to.equal(balanceBefore + mintAmount - burnAmount);
+
+      // Allowance should remain infinite (not reduced)
+      const allowanceAfter = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowanceAfter).to.equal(maxUint256);
+    });
+
+    it("Should verify allowance is spent correctly after partial burn", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const approvalAmount = ethers.parseUnits("1000", 6);
+      const firstBurn = ethers.parseUnits("300", 6);
+      const secondBurn = ethers.parseUnits("400", 6);
+
+      // Get initial balance
+      const balanceBefore = await contractInstance.balanceOf(user1.address);
+
+      // Mint tokens to user1
+      await contractInstance.connect(minter).mint(user1.address, mintAmount);
+
+      // User1 approves minter for 1000 tokens
+      await contractInstance.connect(user1).approve(minter.address, approvalAmount);
+
+      // First burn: 300 tokens
+      await contractInstance.connect(minter).burn(user1.address, firstBurn);
+      let allowance = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowance).to.equal(approvalAmount - firstBurn);
+
+      // Second burn: 400 tokens
+      await contractInstance.connect(minter).burn(user1.address, secondBurn);
+      allowance = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowance).to.equal(approvalAmount - firstBurn - secondBurn);
+
+      // Verify balance
+      const balance = await contractInstance.balanceOf(user1.address);
+      expect(balance).to.equal(balanceBefore + mintAmount - firstBurn - secondBurn);
+
+      // Try to burn more than remaining allowance - should fail
+      const remainingAllowance = approvalAmount - firstBurn - secondBurn;
+      const exceedingBurn = remainingAllowance + ethers.parseUnits("1", 6);
+      await expect(
+        contractInstance.connect(minter).burn(user1.address, exceedingBurn)
+      ).to.be.revertedWithCustomError(contractInstance, "ERC20InsufficientAllowance");
+    });
+  });
+
+  describe("Bridge Burn Authorization Tests", function () {
+    it("Should allow bridge minter to burn their own tokens without approval", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const burnAmount = ethers.parseUnits("500", 6);
+
+      // Mint tokens to the bridge minter
+      await contractInstance.connect(bridgeMinter).bridgeMint(bridgeMinter.address, mintAmount);
+      
+      const balanceBefore = await contractInstance.balanceOf(bridgeMinter.address);
+      expect(balanceBefore).to.equal(mintAmount);
+
+      // Bridge minter should be able to burn their own tokens
+      await expect(
+        contractInstance.connect(bridgeMinter).bridgeBurn(bridgeMinter.address, burnAmount)
+      )
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(bridgeMinter.address, addressZero, burnAmount)
+        .to.emit(contractInstance, "BurnBridge")
+        .withArgs(bridgeMinter.address, bridgeMinter.address, burnAmount);
+
+      const balanceAfter = await contractInstance.balanceOf(bridgeMinter.address);
+      expect(balanceAfter).to.equal(mintAmount - burnAmount);
+    });
+
+    it("Should revert when bridge minter tries to burn from another address without approval", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+
+      // Mint tokens to user2
+      await contractInstance.connect(bridgeMinter).bridgeMint(user2.address, mintAmount);
+
+      // Bridge minter tries to burn from user2 without approval - should fail
+      await expect(
+        contractInstance.connect(bridgeMinter).bridgeBurn(user2.address, mintAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "ERC20InsufficientAllowance");
+    });
+
+    it("Should revert when bridge minter tries to burn from another address with insufficient approval", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const approvalAmount = ethers.parseUnits("500", 6);
+
+      // Mint tokens to user2
+      await contractInstance.connect(bridgeMinter).bridgeMint(user2.address, mintAmount);
+
+      // User2 approves bridge minter for only 500 tokens
+      await contractInstance.connect(user2).approve(bridgeMinter.address, approvalAmount);
+
+      // Bridge minter tries to burn 1000 tokens - should fail
+      await expect(
+        contractInstance.connect(bridgeMinter).bridgeBurn(user2.address, mintAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "ERC20InsufficientAllowance");
+    });
+
+    it("Should allow bridge minter to burn from another address with sufficient approval and reduce allowance", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const burnAmount = ethers.parseUnits("500", 6);
+
+      // Get initial balance
+      const balanceBefore = await contractInstance.balanceOf(user2.address);
+
+      // Mint tokens to user2
+      await contractInstance.connect(bridgeMinter).bridgeMint(user2.address, mintAmount);
+
+      // User2 approves bridge minter for 1000 tokens
+      await contractInstance.connect(user2).approve(bridgeMinter.address, mintAmount);
+
+      const allowanceBefore = await contractInstance.allowance(user2.address, bridgeMinter.address);
+      expect(allowanceBefore).to.equal(mintAmount);
+
+      // Bridge minter burns 500 tokens from user2
+      await expect(
+        contractInstance.connect(bridgeMinter).bridgeBurn(user2.address, burnAmount)
+      )
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(user2.address, addressZero, burnAmount)
+        .to.emit(contractInstance, "BurnBridge")
+        .withArgs(bridgeMinter.address, user2.address, burnAmount);
+
+      const balanceAfter = await contractInstance.balanceOf(user2.address);
+      expect(balanceAfter).to.equal(balanceBefore + mintAmount - burnAmount);
+
+      // Allowance should be reduced by burn amount
+      const allowanceAfter = await contractInstance.allowance(user2.address, bridgeMinter.address);
+      expect(allowanceAfter).to.equal(mintAmount - burnAmount);
+    });
+
+    it("Should allow bridge minter to burn from another address with infinite approval without reducing allowance", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const burnAmount = ethers.parseUnits("500", 6);
+      const maxUint256 = ethers.MaxUint256;
+
+      // Get initial balance
+      const balanceBefore = await contractInstance.balanceOf(user2.address);
+
+      // Mint tokens to user2
+      await contractInstance.connect(bridgeMinter).bridgeMint(user2.address, mintAmount);
+
+      // User2 approves bridge minter for infinite amount
+      await contractInstance.connect(user2).approve(bridgeMinter.address, maxUint256);
+
+      const allowanceBefore = await contractInstance.allowance(user2.address, bridgeMinter.address);
+      expect(allowanceBefore).to.equal(maxUint256);
+
+      // Bridge minter burns 500 tokens from user2
+      await expect(
+        contractInstance.connect(bridgeMinter).bridgeBurn(user2.address, burnAmount)
+      )
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(user2.address, addressZero, burnAmount)
+        .to.emit(contractInstance, "BurnBridge")
+        .withArgs(bridgeMinter.address, user2.address, burnAmount);
+
+      const balanceAfter = await contractInstance.balanceOf(user2.address);
+      expect(balanceAfter).to.equal(balanceBefore + mintAmount - burnAmount);
+
+      // Allowance should remain infinite (not reduced)
+      const allowanceAfter = await contractInstance.allowance(user2.address, bridgeMinter.address);
+      expect(allowanceAfter).to.equal(maxUint256);
+    });
+  });
+
+  describe("Burn Authorization Edge Cases", function () {
+    it("Should revert when trying to burn from blacklisted address", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+
+      // Mint tokens to user3
+      await contractInstance.connect(minter).mint(user3.address, mintAmount);
+
+      // User3 approves minter
+      await contractInstance.connect(user3).approve(minter.address, mintAmount);
+
+      // Blacklist user3
+      await contractInstance.connect(blacklister).blacklist(user3.address);
+
+      // Minter tries to burn from blacklisted address - should fail
+      await expect(
+        contractInstance.connect(minter).burn(user3.address, mintAmount)
+      ).to.be.revertedWithCustomError(contractInstance, "SenderBlacklisted");
+
+      // Unblacklist for cleanup
+      await contractInstance.connect(blacklister).unblacklist(user3.address);
+    });
+
+    it("Should work correctly when using ERC20 Permit for approval followed by burn", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const burnAmount = ethers.parseUnits("500", 6);
+
+      // Get initial balance
+      const balanceBefore = await contractInstance.balanceOf(user1.address);
+
+      // Mint tokens to user1
+      await contractInstance.connect(minter).mint(user1.address, mintAmount);
+
+      // Get permit signature parameters
+      const nonce = await contractInstance.nonces(user1.address);
+      const deadline = (await time.latest()) + 3600; // 1 hour from now
+      const name = await contractInstance.name();
+      const version = "1";
+      const chainId = (await ethers.provider.getNetwork()).chainId;
+
+      // Create permit signature
+      const domain = {
+        name: name,
+        version: version,
+        chainId: chainId,
+        verifyingContract: await contractInstance.getAddress(),
+      };
+
+      const types = {
+        Permit: [
+          { name: "owner", type: "address" },
+          { name: "spender", type: "address" },
+          { name: "value", type: "uint256" },
+          { name: "nonce", type: "uint256" },
+          { name: "deadline", type: "uint256" },
+        ],
+      };
+
+      const value = {
+        owner: user1.address,
+        spender: minter.address,
+        value: mintAmount,
+        nonce: nonce,
+        deadline: deadline,
+      };
+
+      const signature = await user1.signTypedData(domain, types, value);
+      const sig = ethers.Signature.from(signature);
+
+      // Execute permit
+      await contractInstance.permit(
+        user1.address,
+        minter.address,
+        mintAmount,
+        deadline,
+        sig.v,
+        sig.r,
+        sig.s
+      );
+
+      // Verify allowance was set
+      const allowance = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowance).to.equal(mintAmount);
+
+      // Now minter can burn
+      await expect(
+        contractInstance.connect(minter).burn(user1.address, burnAmount)
+      )
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(user1.address, addressZero, burnAmount)
+        .to.emit(contractInstance, "BurnNative")
+        .withArgs(minter.address, user1.address, burnAmount);
+
+      const balanceAfter = await contractInstance.balanceOf(user1.address);
+      expect(balanceAfter).to.equal(balanceBefore + mintAmount - burnAmount);
+    });
+
+    it("Should correctly update allowance and emit Transfer event when burning", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+      const burnAmount = ethers.parseUnits("500", 6);
+
+      // Get initial balance
+      const balanceBefore = await contractInstance.balanceOf(user1.address);
+
+      // Mint tokens to user1
+      await contractInstance.connect(minter).mint(user1.address, mintAmount);
+
+      // User1 approves minter
+      await contractInstance.connect(user1).approve(minter.address, mintAmount);
+
+      const allowanceBefore = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowanceBefore).to.equal(mintAmount);
+
+      // Burn should emit Transfer event and properly update allowance
+      await expect(
+        contractInstance.connect(minter).burn(user1.address, burnAmount)
+      )
+        .to.emit(contractInstance, "Transfer")
+        .withArgs(user1.address, ethers.ZeroAddress, burnAmount)
+        .to.emit(contractInstance, "BurnNative")
+        .withArgs(minter.address, user1.address, burnAmount);
+
+      // Verify allowance was correctly reduced
+      const allowanceAfter = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowanceAfter).to.equal(mintAmount - burnAmount);
+      
+      // Verify balance was reduced to initial + minted - burned
+      const balance = await contractInstance.balanceOf(user1.address);
+      expect(balance).to.equal(balanceBefore + mintAmount - burnAmount);
+    });
+
+    it("Should prevent unauthorized user from burning even with tokens", async function () {
+      const mintAmount = ethers.parseUnits("1000", 6);
+
+      // Mint tokens to user1 and user2
+      await contractInstance.connect(minter).mint(user1.address, mintAmount);
+      await contractInstance.connect(minter).mint(user2.address, mintAmount);
+
+      // User2 approves user1 (who is not a minter)
+      await contractInstance.connect(user2).approve(user1.address, mintAmount);
+
+      // User1 (not a minter) tries to burn user2's tokens - should fail
+      await expect(
+        contractInstance.connect(user1).burn(user2.address, mintAmount)
+      ).to.be.reverted; // Will revert due to lack of MINTER role
+    });
+
+    it("Should handle multiple approvals and burns correctly", async function () {
+      const mintAmount = ethers.parseUnits("3000", 6);
+      const approval1 = ethers.parseUnits("1000", 6);
+      const approval2 = ethers.parseUnits("500", 6);
+      const burn1 = ethers.parseUnits("800", 6);
+      const burn2 = ethers.parseUnits("400", 6);
+
+      // Get initial balance
+      const balanceBefore = await contractInstance.balanceOf(user1.address);
+
+      // Mint tokens to user1
+      await contractInstance.connect(minter).mint(user1.address, mintAmount);
+
+      // First approval and burn
+      await contractInstance.connect(user1).approve(minter.address, approval1);
+      await contractInstance.connect(minter).burn(user1.address, burn1);
+      
+      let allowance = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowance).to.equal(approval1 - burn1);
+
+      // Second approval (replaces existing)
+      await contractInstance.connect(user1).approve(minter.address, approval2);
+      allowance = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowance).to.equal(approval2);
+
+      // Second burn
+      await contractInstance.connect(minter).burn(user1.address, burn2);
+      allowance = await contractInstance.allowance(user1.address, minter.address);
+      expect(allowance).to.equal(approval2 - burn2);
+
+      // Verify final balance
+      const balance = await contractInstance.balanceOf(user1.address);
+      expect(balance).to.equal(balanceBefore + mintAmount - burn1 - burn2);
+    });
   });
 });


### PR DESCRIPTION
Prevents minters from burning tokens without proper approval checks. Updates related tests in pause, rate-limiting, supply-validator, and supply test suites to reflect the new approval requirements.

Ticket: SCAAS-2043