### PR TITLE
refactor: S1: standardize storage location constants

### DIFF
--- a/contracts/Blacklistable.sol
+++ b/contracts/Blacklistable.sol
@@ -15,7 +15,7 @@ contract Blacklistable is
 {
     // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ERC20")) - 1)) & ~bytes32(uint256(0xff))
     // From OpenZeppelin Contracts
-    bytes32 private constant ERC20StorageLocation =
+    bytes32 private constant ERC20_STORAGE_LOCATION =
         0x52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace00;
 
     // Constants for bitmask operations
@@ -189,7 +189,7 @@ contract Blacklistable is
      */
     function getERC20Storage() private pure returns (ERC20Storage storage $) {
         assembly {
-            $.slot := ERC20StorageLocation
+            $.slot := ERC20_STORAGE_LOCATION
         }
     }
 }

--- a/contracts/Stablecoin.sol
+++ b/contracts/Stablecoin.sol
@@ -29,7 +29,7 @@ contract Stablecoin is
     using SafeERC20 for IERC20;
 
     // keccak256(abi.encode(uint256(keccak256("contract.storage.Stablecoin")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant StablecoinStorageLocation = 
+    bytes32 private constant STABLECOIN_STORAGE_LOCATION = 
                     0x9b2d10d13c5ae4f59a8184d905810047d3ab7f6fe6302078b828a0112a6ab900;
 
     /**
@@ -428,11 +428,9 @@ contract Stablecoin is
             }
         }
 
+        delete config.minterParams;
+        delete config.burnerParams;
         config.isConfigured = false;
-        config.minterParams.maxLimit = 0;
-        config.minterParams.currentLimit = 0;
-        config.burnerParams.maxLimit = 0;
-        config.burnerParams.currentLimit = 0;
 
         _revokeRole(isBridge ? BRIDGE_MINTER : MINTER, account);
 
@@ -1165,7 +1163,7 @@ contract Stablecoin is
      */
     function _getStablecoinStorage() private pure returns (StablecoinStorage storage $) {
         assembly {
-            $.slot := StablecoinStorageLocation
+            $.slot := STABLECOIN_STORAGE_LOCATION
         }
     }
 }


### PR DESCRIPTION
Updated the naming convention for storage location constants in both the Blacklistable and Stablecoin contracts to use uppercase letters for consistency.
Removed redundant parameter resets in the Stablecoin contract's configuration.

Ticket: SCAAS-2043