### PR TITLE
feat: update Hardhat configuration for Infura and Etherscan integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add the following environment variables to your `.env`:
 # Deployment Configuration
 DEPLOYMENT_KEY=<your-private-key>
 ETHERSCAN_API_KEY=<your-etherscan-api-key>
-ALCHEMY_API_KEY=<your-alchemy-api-key>
+INFURA_API_KEY=<your-infura-api-key>
 
 # Token Configuration
 TOKEN_NAME=GoUSD                    # e.g., "GoUSD", "GoEUR", "GoGBP"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,8 @@ dotenv.config();
 
 const {
   DEPLOYMENT_KEY,
-  ETHERSCAN_API_KEY
+  ETHERSCAN_API_KEY,
+  INFURA_API_KEY
 } = process.env;
 
 const config: HardhatUserConfig = {
@@ -32,8 +33,13 @@ const config: HardhatUserConfig = {
       accounts: DEPLOYMENT_KEY? [`${DEPLOYMENT_KEY}`]: [],
       chainId: 17000,
     },
+    sepolia: {
+      url: `https://sepolia.infura.io/v3/${INFURA_API_KEY}`,
+      accounts: DEPLOYMENT_KEY ? [`${DEPLOYMENT_KEY}`] : [],
+      chainId: 11155111,
+    },
     mainnet: {
-      url: `https://eth-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+      url: `https://mainnet.infura.io/v3/${INFURA_API_KEY}`,
       accounts: DEPLOYMENT_KEY ? [`${DEPLOYMENT_KEY}`] : [],
       chainId: 1,
     },
@@ -44,22 +50,35 @@ const config: HardhatUserConfig = {
     }
   },
   etherscan: {
-    apiKey: `${ETHERSCAN_API_KEY}`,
+    enabled: true,
+    apiKey: {
+      mainnet: `${ETHERSCAN_API_KEY}`,
+      sepolia: `${ETHERSCAN_API_KEY}`,
+      holesky: `${ETHERSCAN_API_KEY}`,
+    },
     customChains: [
+      {
+        network: 'mainnet',
+        chainId: 1,
+        urls: {
+          apiURL: 'https://api.etherscan.io/v2/api?chainid=1',
+          browserURL: 'https://etherscan.io'
+        }
+      },
       {
         network: 'holesky',
         chainId: 17000,
         urls: {
-          apiURL: 'https://api-holesky.etherscan.io/api',
+          apiURL: 'https://api.etherscan.io/v2/api?chainid=17000',
           browserURL: 'https://holesky.etherscan.io'
         }
       },
       {
-        network: 'hoodi',
-        chainId: 560048,
+        network: 'sepolia',
+        chainId: 11155111,
         urls: {
-          apiURL: 'https://api-hoodi.etherscan.io/api',
-          browserURL: 'https://hoodi.etherscan.io'
+          apiURL: 'https://api.etherscan.io/v2/api?chainid=11155111',
+          browserURL: 'https://sepolia.etherscan.io'
         }
       },
     ],


### PR DESCRIPTION
- Added INFURA_API_KEY to the Hardhat configuration for Sepolia and Mainnet networks.
- Updated the Etherscan configuration to support multiple networks (mainnet, sepolia, holesky) with the same API key.
- Updated dependencies in package.json and package-lock.json, including hardhat-ethers to version 3.1.2 and ethers to version 6.16.0.

Ticket:  SCAAS-2136