### PR TITLE
chore: update prevent-lockfile-modifications workflow reference

### DIFF
--- a/.github/workflows/prevent-lockfile-modifications.yaml
+++ b/.github/workflows/prevent-lockfile-modifications.yaml
@@ -4,6 +4,6 @@ on:
 jobs:
   prevent-lockfile-modifications:
     name: Prevent Lockfile Modifications
-    uses: BitGo/static-analysis/.github/workflows/prevent-lockfile-modifications.yaml@v1
+    uses: BitGo/build-system/.github/workflows/prevent-lockfile-modifications.yaml@v6
     secrets:
       vault-cf-access-client-secret: ${{ secrets.VAULT_CF_ACCESS_CLIENT_SECRET }}


### PR DESCRIPTION
## Summary
- Update reusable workflow reference from `BitGo/static-analysis` to `BitGo/build-system`
- The `prevent-lockfile-modifications` workflow has been moved to the build-system repository

Ticket: VL-4160