### PR TITLE
docs: add DCO and GOVERNANCE files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,19 @@ npm run format
 - Use clear, descriptive commit messages
 - Reference issue numbers where applicable (e.g., `fix: resolve blacklist check on zero address (#42)`)
 
+### Developer Certificate of Origin (DCO)
+
+All contributions must be made under the [Developer Certificate of Origin](./DCO.md).
+Every commit must include a `Signed-off-by` line matching the commit author,
+which you can add automatically with `git commit -s`:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Pull requests containing commits without a valid sign-off cannot be merged. See
+[DCO.md](./DCO.md) for details.
+
 ## Submitting Changes
 
 1. Ensure all tests pass: `npm test`
@@ -78,7 +91,7 @@ npm run format
 
 ## Governance
 
-This project is maintained by BitGo's Stablecoins team. The maintainers are responsible for reviewing and merging contributions, managing releases, and setting the project roadmap.
+This project is maintained by BitGo's Stablecoins team. The maintainers are responsible for reviewing and merging contributions, managing releases, and setting the project roadmap. See [GOVERNANCE.md](./GOVERNANCE.md) for the full governance model, roles, and decision-making process.
 
 ## License
 

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,69 @@
+# Developer Certificate of Origin
+
+This project uses the [Developer Certificate of Origin (DCO)](https://developercertificate.org/)
+version 1.1 to manage contributions. The DCO is a lightweight, per-commit
+attestation that you have the right to submit your contribution under the
+project's [Apache License 2.0](./LICENSE.md).
+
+By adding a `Signed-off-by` line to a commit, you certify the following:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+## How to sign off
+
+Add a `Signed-off-by` line to every commit message, using your real name and an
+email address you can be reached at:
+
+```
+Signed-off-by: Jane Doe <jane.doe@example.com>
+```
+
+Git can add this automatically with the `-s` flag:
+
+```bash
+git commit -s -m "fix: correct blacklist check on zero address"
+```
+
+If you forget to sign off, you can amend the most recent commit:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+Every commit in a pull request must be signed off. Pull requests containing
+unsigned commits cannot be merged.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,87 @@
+# Governance
+
+This document describes the governance model for the `stablecoin-evm` project: the
+roles participants can hold, how decisions are made, and how the community
+participates.
+
+## Overview
+
+`stablecoin-evm` is an open source project maintained by BitGo. BitGo retains
+final decision-making authority over the project's direction, releases, and
+acceptance of contributions. The project follows a **maintainer (BDFL-style)
+governance model** with a designated set of maintainers from BitGo's Stablecoins
+team.
+
+## Roles
+
+### Users
+Anyone who uses the software. Users are encouraged to participate by reporting
+bugs, requesting features, and joining discussions via GitHub Issues.
+
+### Contributors
+Anyone who contributes code, documentation, tests, or reviews. Contributions are
+made via pull requests and are subject to the process in
+[CONTRIBUTING.md](./CONTRIBUTING.md), including the Developer Certificate of
+Origin sign-off described in [DCO.md](./DCO.md). Contributors do not need any
+special permissions beyond a GitHub account and a signed-off commit.
+
+### Maintainers
+Maintainers are BitGo employees on the Stablecoins team (see
+[CODEOWNERS](./CODEOWNERS)). Maintainers are responsible for:
+
+- Reviewing, approving, and merging pull requests
+- Triaging issues and setting the project roadmap
+- Cutting and publishing releases
+- Enforcing the contribution process and community guidelines
+- Coordinating security disclosures (see [SECURITY.md](./SECURITY.md))
+
+The current maintainer group is `@BitGo/stablecoins`.
+
+### Project Owner
+BitGo, Inc. is the project owner and copyright holder. BitGo holds final
+authority over licensing, trademark, the maintainer roster, and any decision to
+archive, transfer, or wind down the project.
+
+## Decision Making
+
+- **Routine changes** (bug fixes, tests, documentation, dependency bumps) are
+  decided by maintainer review — at least one maintainer approval and passing CI
+  are required to merge.
+- **Significant changes** (public API/interface changes, new roles, storage
+  layout changes affecting upgradeability, changes to security-sensitive logic)
+  require review and approval by at least two maintainers.
+- **Disagreements** are resolved by discussion among maintainers. If consensus
+  cannot be reached, the BitGo Stablecoins team lead makes the final decision.
+
+## Contribution Acceptance
+
+All external contributions require:
+
+1. A signed-off commit per the Developer Certificate of Origin (see
+   [DCO.md](./DCO.md)).
+2. Passing CI (unit tests and linting).
+3. Approval from at least one maintainer (two for significant changes).
+
+Maintainers may decline contributions that fall outside the project's scope,
+introduce unacceptable risk, or conflict with BitGo's roadmap.
+
+## Security
+
+Security vulnerabilities must be reported privately per [SECURITY.md](./SECURITY.md).
+Security fixes are coordinated by maintainers under a responsible disclosure
+process and may be developed privately before public release.
+
+## Releases
+
+Maintainers cut releases following [Semantic Versioning](https://semver.org/) and
+document every published version in [CHANGELOG.md](./CHANGELOG.md).
+
+## Changes to Governance
+
+This governance model is maintained by BitGo. Changes are proposed via pull
+request and require approval from the BitGo Stablecoins team lead.
+
+## Contact
+
+For questions about governance or the project, open a GitHub Issue. For security
+matters, email security@bitgo.com.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
   },
   "author": "BitGo",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BitGo/stablecoin-evm.git"
+  },
+  "bugs": {
+    "url": "https://github.com/BitGo/stablecoin-evm/issues"
+  },
+  "homepage": "https://github.com/BitGo/stablecoin-evm#readme",
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.0",
     "@openzeppelin/contracts-upgradeable": "^5.0.0",


### PR DESCRIPTION
this change adds the DCO and GOVERNANCE files to the repository, providing guidelines for contributors and outlining the governance structure of the project. The CONTRIBUTING.md file has also been updated to reference these new documents.

Ticket: SCAAS-10182