### PR TITLE
feat: add deterministic deploy script

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -17,6 +17,10 @@ const {
   BSCSCAN_API_KEY,
   BSC_RPC_URL,
   BSC_TESTNET_RPC_URL,
+  POLYGON_RPC_URL,
+  MONAD_RPC_URL,
+  POLYGON_AMOY_RPC_URL,
+  MONAD_TESTNET_RPC_URL,
 } = process.env;
 
 const targetNetwork = process.env.HARDHAT_NETWORK;
@@ -25,6 +29,18 @@ if (targetNetwork === "bsc" && !BSC_RPC_URL) {
 }
 if (targetNetwork === "bscTestnet" && !BSC_TESTNET_RPC_URL) {
   console.warn("Warning: BSC_TESTNET_RPC_URL is not set. Falling back to public RPC. Set BSC_TESTNET_RPC_URL in .env.");
+}
+if (targetNetwork === "polygon" && !POLYGON_RPC_URL) {
+  console.warn("Warning: POLYGON_RPC_URL is not set. Falling back to public RPC — not safe for production deployments. Set POLYGON_RPC_URL in .env.");
+}
+if (targetNetwork === "monad" && !MONAD_RPC_URL) {
+  console.warn("Warning: MONAD_RPC_URL is not set. Falling back to public RPC — not safe for production deployments. Set MONAD_RPC_URL in .env.");
+}
+if (targetNetwork === "polygonAmoy" && !POLYGON_AMOY_RPC_URL) {
+  console.warn("Warning: POLYGON_AMOY_RPC_URL is not set. Falling back to public RPC. Set POLYGON_AMOY_RPC_URL in .env.");
+}
+if (targetNetwork === "monadTestnet" && !MONAD_TESTNET_RPC_URL) {
+  console.warn("Warning: MONAD_TESTNET_RPC_URL is not set. Falling back to public RPC. Set MONAD_TESTNET_RPC_URL in .env.");
 }
 
 const config: HardhatUserConfig = {
@@ -72,7 +88,30 @@ const config: HardhatUserConfig = {
       accounts: DEPLOYMENT_KEY ? [`${DEPLOYMENT_KEY}`] : [],
       chainId: 97,
     },
+    polygon: {
+      url: POLYGON_RPC_URL?.trim() || 'https://polygon.drpc.org',
+      accounts: DEPLOYMENT_KEY ? [`${DEPLOYMENT_KEY}`] : [],
+      chainId: 137,
+    },
+    monad: {
+      url: MONAD_RPC_URL?.trim() || 'https://rpc.monad.xyz',
+      accounts: DEPLOYMENT_KEY ? [`${DEPLOYMENT_KEY}`] : [],
+      chainId: 143,
+    },
+    polygonAmoy: {
+      url: POLYGON_AMOY_RPC_URL?.trim() || 'https://polygon-amoy-public.nodies.app',
+      accounts: DEPLOYMENT_KEY ? [`${DEPLOYMENT_KEY}`] : [],
+      chainId: 80002,
+    },
+    monadTestnet: {
+      url: MONAD_TESTNET_RPC_URL?.trim() || 'https://testnet-rpc.monad.xyz',
+      accounts: DEPLOYMENT_KEY ? [`${DEPLOYMENT_KEY}`] : [],
+      chainId: 10143,
+    },
   },
+  sourcify: {
+    enabled: true,
+},
   etherscan: {
     enabled: true,
     apiKey: {
@@ -82,6 +121,10 @@ const config: HardhatUserConfig = {
       hoodi: `${ETHERSCAN_API_KEY}`,
       bsc: BSCSCAN_API_KEY ?? '',
       bscTestnet: BSCSCAN_API_KEY ?? '',
+      polygon: `${ETHERSCAN_API_KEY}`,
+      monad: `${ETHERSCAN_API_KEY}`,
+      polygonAmoy: `${ETHERSCAN_API_KEY}`,
+      monadTestnet: `${ETHERSCAN_API_KEY}`,
     },
     customChains: [
       {
@@ -130,6 +173,38 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: 'https://api-testnet.bscscan.com/api',
           browserURL: 'https://testnet.bscscan.com'
+        }
+      },
+      {
+        network: 'polygon',
+        chainId: 137,
+        urls: {
+          apiURL: 'https://api.etherscan.io/v2/api?chainid=137',
+          browserURL: 'https://polygonscan.com'
+        }
+      },
+      {
+        network: 'monad',
+        chainId: 143,
+        urls: {
+          apiURL: 'https://api.etherscan.io/v2/api?chainid=143',
+          browserURL: 'https://monadscan.com'
+        }
+      },
+      {
+        network: 'polygonAmoy',
+        chainId: 80002,
+        urls: {
+          apiURL: 'https://api.etherscan.io/v2/api?chainid=80002',
+          browserURL: 'https://amoy.polygonscan.com'
+        }
+      },
+      {
+        network: 'monadTestnet',
+        chainId: 10143,
+        urls: {
+          apiURL: 'https://api.etherscan.io/v2/api?chainid=10143',
+          browserURL: 'https://testnet.monadscan.com'
         }
       }
     ],

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,39 @@ RESCUER_ADDRESS=0x... \
 npx hardhat run scripts/deploy-token.ts --network mainnet
 ```
 
+### 1b. Reproduce an Existing Address on a New Chain - `deploy-deterministic.ts`
+
+Use this instead of `deploy-token.ts` when the token is already deployed on another
+chain and the new deployment must land at the **same address**. Address parity relies
+on CREATE semantics: same deployer EOA + same nonces (implementation at nonce N,
+proxy at nonce N+1). The script refuses to broadcast unless every precondition holds,
+and never hardcodes a gas limit (so reverting transactions fail off-chain during gas
+estimation instead of burning a nonce on-chain).
+
+Takes all `deploy-token.ts` variables plus:
+
+| Variable | Description |
+|----------|-------------|
+| `EXPECTED_CHAIN_ID` | Chain id the RPC must report (e.g. `137`, `143`) |
+| `EXPECTED_DEPLOYER_ADDRESS` | Deployer EOA used on the reference chain |
+| `EXPECTED_PROXY_ADDRESS` | Token (proxy) address to reproduce |
+| `EXPECTED_IMPLEMENTATION_ADDRESS` | (Optional) implementation address to reproduce |
+| `REFERENCE_RPC_URL` | (Optional) RPC of the chain where the token already exists; preflight verifies name/symbol/decimals AND runtime bytecode against the live token and aborts on mismatch. Unset: mainnet targets default to Ethereum mainnet (needs `INFURA_API_KEY`), testnet targets to Hoodi |
+| `ALLOW_BYTECODE_MISMATCH` | (Optional) set `true` to proceed when the compiled bytecode differs from the reference implementation (i.e. intentionally deploying newer contract code) |
+| `GAS_BUFFER_PERCENT` | (Optional) balance-check buffer, default `25` |
+| `DRY_RUN` | Set `true` to run all preflight checks without broadcasting |
+
+```bash
+DRY_RUN=true TOKEN_NAME=... TOKEN_SYMBOL=... TOKEN_DECIMALS=6 DEFAULT_MINT_CAP=... \
+ADMIN_ADDRESS=0x... DEFAULT_ADMIN_DELAY=... FREEZER_ADDRESS=0x... \
+MASTER_MINTER_ADDRESS=0x... UPGRADER_ADDRESS=0x... BLACKLISTER_ADDRESS=0x... \
+RESCUER_ADDRESS=0x... EXPECTED_CHAIN_ID=137 EXPECTED_DEPLOYER_ADDRESS=0x... \
+EXPECTED_PROXY_ADDRESS=0x... EXPECTED_IMPLEMENTATION_ADDRESS=0x... \
+npx hardhat run scripts/deploy-deterministic.ts --network polygon
+```
+
+Run once with `DRY_RUN=true`, review the preflight output, then run without it.
+
 ### 2. Upgrade Any Token - `upgrade-token.ts`
 
 Upgrade any stablecoin by specifying the token name and proxy address:

--- a/scripts/deploy-deterministic.ts
+++ b/scripts/deploy-deterministic.ts
@@ -1,0 +1,749 @@
+// Copyright (c) 2026 BitGo, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ethers, upgrades, artifacts } from "hardhat";
+import { networkNames } from "@openzeppelin/upgrades-core";
+import type { Provider } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Deterministic deployment script for reproducing an existing token address
+ * on a new chain.
+ *
+ * A CREATE-deployed contract's address is derived from (deployer, nonce).
+ * To land the proxy at the SAME address as on another chain (e.g. Ethereum),
+ * the SAME deployer EOA must broadcast the proxy-creation transaction at the
+ * SAME nonce. `upgrades.deployProxy` on a fresh chain sends exactly two
+ * transactions:
+ *
+ *   nonce N     -> Stablecoin implementation
+ *   nonce N + 1 -> ERC1967 proxy (this is the token address)
+ *
+ * This script refuses to broadcast anything unless every precondition for
+ * reproducing the expected address is verified. All failure modes that would
+ * consume a nonce on-chain (out-of-gas from a hardcoded gas limit, reverting
+ * initializer, insufficient balance mid-sequence) are checked or estimated
+ * BEFORE any transaction is sent, because a single failed on-chain tx burns
+ * the nonce and makes the target address permanently unreachable.
+ *
+ * Usage (example: SOFI on Polygon):
+ *   TOKEN_NAME=... TOKEN_SYMBOL=SOFI TOKEN_DECIMALS=6 \
+ *   DEFAULT_MINT_CAP=... ADMIN_ADDRESS=0x... DEFAULT_ADMIN_DELAY=... \
+ *   FREEZER_ADDRESS=0x... MASTER_MINTER_ADDRESS=0x... UPGRADER_ADDRESS=0x... \
+ *   BLACKLISTER_ADDRESS=0x... RESCUER_ADDRESS=0x... \
+ *   EXPECTED_CHAIN_ID=137 \
+ *   EXPECTED_DEPLOYER_ADDRESS=0x571aFFbdaf5B4ACE4C54f7E729a379D6FC4820d8 \
+ *   EXPECTED_PROXY_ADDRESS=0x0CB6d03B0aC88A463F67B7Ad99f9f3ec4678092E \
+ *   EXPECTED_IMPLEMENTATION_ADDRESS=0x69eDf9Fa820Df057E493635ed1dB6b9E5F8124A0 \
+ *   npx hardhat run scripts/deploy-deterministic.ts --network polygon
+ *
+ * Additional environment variables (on top of deploy-token.ts variables):
+ * - EXPECTED_CHAIN_ID: chain id the connected RPC must report (e.g. 137, 143)
+ * - EXPECTED_DEPLOYER_ADDRESS: the EOA that deployed on the reference chain
+ * - EXPECTED_PROXY_ADDRESS: the token (proxy) address to reproduce
+ * - EXPECTED_IMPLEMENTATION_ADDRESS: (optional) implementation address to reproduce
+ * - REFERENCE_RPC_URL: (optional) RPC of the chain where the token is ALREADY
+ *   deployed (e.g. Ethereum mainnet for SOFID). Preflight reads
+ *   name/symbol/decimals from EXPECTED_PROXY_ADDRESS there and aborts if they do
+ *   not match TOKEN_NAME/TOKEN_SYMBOL/TOKEN_DECIMALS, guaranteeing metadata parity.
+ *   When unset, a per-target default is used: mainnet targets reference Ethereum
+ *   mainnet (requires INFURA_API_KEY), testnet targets reference Hoodi.
+ * - GAS_BUFFER_PERCENT: (optional) buffer applied on top of gas estimates, default 25
+ * - DRY_RUN: (optional) if "true", run every preflight check and exit without broadcasting
+ */
+
+const ERC1967_IMPLEMENTATION_SLOT =
+  "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+
+// Rough upper bound for the ERC1967 proxy deployment + initializer execution.
+// Used ONLY for the balance preflight (the actual tx is estimated by the node
+// right before broadcast). The SOFI proxy on Ethereum used ~1.1M gas.
+const PROXY_GAS_UPPER_BOUND = 3_000_000n;
+
+export interface DeterministicConfig {
+  tokenName: string;
+  tokenSymbol: string;
+  tokenDecimals: number;
+  defaultMintCap: bigint;
+  adminAddress: string;
+  defaultAdminDelay: bigint;
+  freezerAddress: string;
+  masterMinterAddress: string;
+  upgraderAddress: string;
+  blacklisterAddress: string;
+  rescuerAddress: string;
+  expectedChainId: bigint;
+  expectedDeployer: string | undefined;
+  expectedProxy: string;
+  expectedImplementation: string | undefined;
+  referenceRpcUrl: string | undefined;
+  allowBytecodeMismatch: boolean;
+  gasBufferPercent: bigint;
+  dryRun: boolean;
+}
+
+function fail(message: string): never {
+  throw new Error(`PREFLIGHT FAILED: ${message}`);
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    fail(`missing required environment variable ${name}`);
+  }
+  return value.trim();
+}
+
+/** Validates address format and (for mixed-case input) checksum, so a
+ * mangled address cannot slip through. Returns the checksummed form. */
+function requireAddress(name: string, value: string): string {
+  let checksummed: string;
+  try {
+    checksummed = ethers.getAddress(value);
+  } catch {
+    fail(`${name} is not a valid EVM address: "${value}"`);
+  }
+  if (checksummed === ethers.ZeroAddress) {
+    fail(`${name} must not be the zero address`);
+  }
+  return checksummed;
+}
+
+function requireBigInt(name: string, value: string): bigint {
+  let parsed: bigint;
+  try {
+    parsed = BigInt(value);
+  } catch {
+    fail(`${name} is not a valid integer: "${value}"`);
+  }
+  if (parsed < 0n) {
+    fail(`${name} must not be negative: ${parsed}`);
+  }
+  return parsed;
+}
+
+/**
+ * Default reference RPC for a given TARGET chain when REFERENCE_RPC_URL is not
+ * set explicitly. Mainnet targets reference Ethereum mainnet (where the
+ * production tokens live); testnet targets reference Hoodi (the team's
+ * rehearsal reference chain). An explicit REFERENCE_RPC_URL always wins.
+ */
+export function defaultReferenceRpcUrl(targetChainId: bigint): string | undefined {
+  const MAINNET_TARGETS = [1n, 56n, 137n, 143n];
+  const TESTNET_TARGETS = [97n, 17000n, 11155111n, 80002n, 10143n];
+  if (MAINNET_TARGETS.includes(targetChainId)) {
+    const infuraKey = process.env.INFURA_API_KEY?.trim();
+    return infuraKey ? `https://mainnet.infura.io/v3/${infuraKey}` : undefined;
+  }
+  if (TESTNET_TARGETS.includes(targetChainId)) {
+    return "https://rpc.hoodi.ethpandaops.io";
+  }
+  return undefined;
+}
+
+export function loadConfig(): DeterministicConfig {
+  if (process.env.PROXY_CONTRACT_ADDRESS) {
+    fail(
+      "PROXY_CONTRACT_ADDRESS is set, which means this contract is already deployed. " +
+        "Use scripts/manage-roles.ts to update roles instead."
+    );
+  }
+
+  // The following limits mirror Stablecoin.initialize's own validation
+  // (InvalidDecimals / InvalidDelay / LimitTooLow). Values the initializer
+  // would revert on MUST be rejected here, before anything is broadcast:
+  // discovered on-chain, the revert would surface only at the proxy step,
+  // after the implementation tx already consumed nonce N — stranding the
+  // deterministic sequence.
+  const decimals = Number(requireBigInt("TOKEN_DECIMALS", requireEnv("TOKEN_DECIMALS")));
+  if (decimals === 0 || decimals > 18) {
+    fail(
+      `TOKEN_DECIMALS is ${decimals}; Stablecoin.initialize requires 1-18 (InvalidDecimals).`
+    );
+  }
+
+  // Stablecoin._MIN_LIMIT — initialize reverts with LimitTooLow below this.
+  const STABLECOIN_MIN_LIMIT = 86400n;
+  const mintCap = requireBigInt("DEFAULT_MINT_CAP", requireEnv("DEFAULT_MINT_CAP"));
+  if (mintCap < STABLECOIN_MIN_LIMIT) {
+    fail(
+      `DEFAULT_MINT_CAP is ${mintCap}; Stablecoin.initialize requires >= ${STABLECOIN_MIN_LIMIT} ` +
+        "(_MIN_LIMIT, LimitTooLow)."
+    );
+  }
+
+  const adminDelay = requireBigInt("DEFAULT_ADMIN_DELAY", requireEnv("DEFAULT_ADMIN_DELAY"));
+  if (adminDelay === 0n) {
+    fail("DEFAULT_ADMIN_DELAY must be > 0; Stablecoin.initialize reverts on zero (InvalidDelay).");
+  }
+
+  return {
+    tokenName: requireEnv("TOKEN_NAME"),
+    tokenSymbol: requireEnv("TOKEN_SYMBOL"),
+    tokenDecimals: decimals,
+    defaultMintCap: mintCap,
+    adminAddress: requireAddress("ADMIN_ADDRESS", requireEnv("ADMIN_ADDRESS")),
+    defaultAdminDelay: adminDelay,
+    freezerAddress: requireAddress("FREEZER_ADDRESS", requireEnv("FREEZER_ADDRESS")),
+    masterMinterAddress: requireAddress("MASTER_MINTER_ADDRESS", requireEnv("MASTER_MINTER_ADDRESS")),
+    upgraderAddress: requireAddress("UPGRADER_ADDRESS", requireEnv("UPGRADER_ADDRESS")),
+    blacklisterAddress: requireAddress("BLACKLISTER_ADDRESS", requireEnv("BLACKLISTER_ADDRESS")),
+    rescuerAddress: requireAddress("RESCUER_ADDRESS", requireEnv("RESCUER_ADDRESS")),
+    expectedChainId: requireBigInt("EXPECTED_CHAIN_ID", requireEnv("EXPECTED_CHAIN_ID")),
+    expectedDeployer: process.env.EXPECTED_DEPLOYER_ADDRESS
+      ? requireAddress("EXPECTED_DEPLOYER_ADDRESS", process.env.EXPECTED_DEPLOYER_ADDRESS)
+      : undefined,
+    expectedProxy: requireAddress("EXPECTED_PROXY_ADDRESS", requireEnv("EXPECTED_PROXY_ADDRESS")),
+    expectedImplementation: process.env.EXPECTED_IMPLEMENTATION_ADDRESS
+      ? requireAddress("EXPECTED_IMPLEMENTATION_ADDRESS", process.env.EXPECTED_IMPLEMENTATION_ADDRESS)
+      : undefined,
+    referenceRpcUrl:
+      process.env.REFERENCE_RPC_URL?.trim() ||
+      defaultReferenceRpcUrl(requireBigInt("EXPECTED_CHAIN_ID", requireEnv("EXPECTED_CHAIN_ID"))),
+    allowBytecodeMismatch: process.env.ALLOW_BYTECODE_MISMATCH === "true",
+    gasBufferPercent: process.env.GAS_BUFFER_PERCENT
+      ? requireBigInt("GAS_BUFFER_PERCENT", process.env.GAS_BUFFER_PERCENT)
+      : 25n,
+    dryRun: process.env.DRY_RUN === "true",
+  };
+}
+
+/**
+ * An existing OpenZeppelin network manifest changes deployProxy's behavior:
+ * if it already records this implementation, the implementation deploy is
+ * SKIPPED and the proxy lands one nonce earlier than expected, producing the
+ * wrong address. A fresh chain must have no manifest.
+ */
+export function checkNoOzManifest(chainId: bigint): void {
+  // Resolve manifest names exactly the way @openzeppelin/upgrades-core does:
+  // the network's registered name if it has one, with unknown-<chainId>.json
+  // always considered as the fallback. Importing OZ's own map means new
+  // networks can never silently drift out of this check.
+  const candidates = new Set([`unknown-${chainId}.json`]);
+  const known = networkNames[Number(chainId)];
+  if (known) {
+    candidates.add(`${known}.json`);
+  }
+  for (const candidate of candidates) {
+    const manifestPath = path.join(__dirname, "..", ".openzeppelin", candidate);
+    if (fs.existsSync(manifestPath)) {
+      fail(
+        `OpenZeppelin manifest ${manifestPath} already exists for chain ${chainId}. ` +
+          "If it records this implementation, deployProxy will SKIP the implementation " +
+          "transaction and the proxy will land at the wrong nonce (wrong address). " +
+          "Move the manifest aside (do not delete — archive it like the other " +
+          ".openzeppelin/*-<token>.json files) and re-run."
+      );
+    }
+  }
+}
+
+export const ERC20_METADATA_ABI = [
+  "function name() view returns (string)",
+  "function symbol() view returns (string)",
+  "function decimals() view returns (uint8)",
+];
+
+/**
+ * Reads name/symbol/decimals from the ALREADY-DEPLOYED token at
+ * config.expectedProxy on the reference chain and fails unless they exactly
+ * match the values this deployment would initialize with. Guarantees the new
+ * chain's token is metadata-identical to the reference, not just
+ * address-identical.
+ */
+export async function verifyReferenceMetadata(
+  config: DeterministicConfig,
+  referenceProvider: Provider
+): Promise<void> {
+  let code: string;
+  try {
+    code = await referenceProvider.getCode(config.expectedProxy);
+  } catch (error) {
+    fail(`could not reach the reference RPC: ${error}`);
+  }
+  if (code === "0x") {
+    fail(
+      `no contract at ${config.expectedProxy} on the reference chain. ` +
+        "REFERENCE_RPC_URL must point at the chain where the token is already deployed."
+    );
+  }
+
+  const token = new ethers.Contract(config.expectedProxy, ERC20_METADATA_ABI, referenceProvider);
+  let refName: string, refSymbol: string, refDecimals: bigint;
+  try {
+    [refName, refSymbol, refDecimals] = await Promise.all([
+      token.name(),
+      token.symbol(),
+      token.decimals(),
+    ]);
+  } catch (error) {
+    fail(`could not read ERC20 metadata from the reference token: ${error}`);
+  }
+
+  const mismatches: string[] = [];
+  if (refName !== config.tokenName) {
+    mismatches.push(`name: reference is "${refName}" but TOKEN_NAME is "${config.tokenName}"`);
+  }
+  if (refSymbol !== config.tokenSymbol) {
+    mismatches.push(
+      `symbol: reference is "${refSymbol}" but TOKEN_SYMBOL is "${config.tokenSymbol}"`
+    );
+  }
+  if (Number(refDecimals) !== config.tokenDecimals) {
+    mismatches.push(
+      `decimals: reference is ${refDecimals} but TOKEN_DECIMALS is ${config.tokenDecimals}`
+    );
+  }
+  if (mismatches.length > 0) {
+    fail(
+      `token metadata does not match the reference deployment:\n    - ${mismatches.join("\n    - ")}`
+    );
+  }
+}
+
+/**
+ * Strips the CBOR metadata trailer the Solidity compiler appends to runtime
+ * bytecode (last two bytes encode the trailer length). Returns undefined if
+ * the bytecode is too short or the encoded length is implausible.
+ */
+export function stripCborMetadata(bytecodeHex: string): string | undefined {
+  const bytes = ethers.getBytes(bytecodeHex);
+  if (bytes.length < 4) {
+    return undefined;
+  }
+  const trailerLength = (bytes[bytes.length - 2] << 8) | bytes[bytes.length - 1];
+  const total = trailerLength + 2;
+  if (total >= bytes.length) {
+    return undefined;
+  }
+  return ethers.hexlify(bytes.slice(0, bytes.length - total));
+}
+
+/**
+ * Verifies the runtime bytecode this deployment will produce is identical to
+ * the implementation live behind the reference proxy.
+ *
+ * The locally compiled artifact has placeholder zeros where immutables live
+ * (UUPS embeds `address(this)`), so those positions are filled with the
+ * reference implementation address before comparing — valid because the
+ * implementation deploys at the SAME address on the new chain. If only the
+ * compiler's CBOR metadata trailer differs (source formatting/paths), that is
+ * reported but allowed; a logic difference fails unless
+ * ALLOW_BYTECODE_MISMATCH=true.
+ */
+export async function verifyReferenceBytecode(
+  config: DeterministicConfig,
+  referenceProvider: Provider
+): Promise<void> {
+  // Resolve the reference implementation from the proxy's ERC1967 slot.
+  let slotValue: string;
+  try {
+    slotValue = await referenceProvider.getStorage(
+      config.expectedProxy,
+      ERC1967_IMPLEMENTATION_SLOT
+    );
+  } catch (error) {
+    fail(`could not read the reference proxy's implementation slot: ${error}`);
+  }
+  const referenceImpl = ethers.getAddress(ethers.dataSlice(ethers.zeroPadValue(slotValue, 32), 12));
+  if (referenceImpl === ethers.ZeroAddress) {
+    fail(
+      `the contract at ${config.expectedProxy} on the reference chain has no ERC1967 ` +
+        "implementation — is it really the token proxy?"
+    );
+  }
+  if (config.expectedImplementation && referenceImpl !== config.expectedImplementation) {
+    fail(
+      `reference proxy points at implementation ${referenceImpl} but ` +
+        `EXPECTED_IMPLEMENTATION_ADDRESS is ${config.expectedImplementation}. The reference ` +
+        "token may have been upgraded since those expectations were recorded."
+    );
+  }
+
+  const referenceCode = await referenceProvider.getCode(referenceImpl);
+  if (referenceCode === "0x") {
+    fail(`no code at the reference implementation ${referenceImpl}`);
+  }
+
+  // Build the runtime bytecode this deployment will produce: the compiled
+  // artifact with immutable positions filled with the implementation address.
+  const artifact = await artifacts.readArtifact("Stablecoin");
+  const localBytes = ethers.getBytes(artifact.deployedBytecode);
+  const buildInfo = await artifacts.getBuildInfo("contracts/Stablecoin.sol:Stablecoin");
+  const immutableReferences =
+    buildInfo?.output.contracts?.["contracts/Stablecoin.sol"]?.["Stablecoin"]?.evm
+      ?.deployedBytecode?.immutableReferences ?? {};
+  for (const references of Object.values(immutableReferences)) {
+    for (const { start, length } of references) {
+      if (start + length > localBytes.length) {
+        fail(`immutable reference at ${start} (+${length}) exceeds local bytecode length`);
+      }
+      localBytes.set(ethers.getBytes(ethers.zeroPadValue(referenceImpl, length)), start);
+    }
+  }
+  const localCode = ethers.hexlify(localBytes);
+
+  if (localCode.toLowerCase() === referenceCode.toLowerCase()) {
+    return; // byte-for-byte identical, metadata included
+  }
+
+  const localStripped = stripCborMetadata(localCode);
+  const referenceStripped = stripCborMetadata(referenceCode);
+  if (
+    localStripped !== undefined &&
+    referenceStripped !== undefined &&
+    localStripped.toLowerCase() === referenceStripped.toLowerCase()
+  ) {
+    console.warn(
+      "  ! logic bytecode matches the reference implementation, but the CBOR metadata " +
+        "trailer differs (source formatting, file paths, or compiler metadata settings). " +
+        "Functionally identical; explorer verification may show a different metadata hash."
+    );
+    return;
+  }
+
+  const message =
+    `compiled runtime bytecode does not match the reference implementation ${referenceImpl} ` +
+    `(local ${localBytes.length} bytes vs reference ${(referenceCode.length - 2) / 2} bytes). ` +
+    "The contract source or compiler settings have changed since the reference deployment.";
+  if (config.allowBytecodeMismatch) {
+    console.warn(
+      `  ! ${message}\n  ! Proceeding because ALLOW_BYTECODE_MISMATCH=true — the new chain ` +
+        "will run DIFFERENT code than the reference chain."
+    );
+    return;
+  }
+  fail(`${message} Set ALLOW_BYTECODE_MISMATCH=true only if deploying newer code is intentional.`);
+}
+
+export async function preflight(config: DeterministicConfig): Promise<{ deployer: string }> {
+  const provider = ethers.provider;
+  const checks: string[] = [];
+  const pass = (msg: string) => {
+    checks.push(msg);
+    console.log(`  ✓ ${msg}`);
+  };
+
+  console.log("\n=== Preflight checks ===");
+
+  // 1. Chain identity: the RPC must actually be the chain we think it is.
+  const network = await provider.getNetwork();
+  if (network.chainId !== config.expectedChainId) {
+    fail(
+      `connected RPC reports chainId ${network.chainId} but EXPECTED_CHAIN_ID is ` +
+        `${config.expectedChainId}. Wrong --network flag or wrong RPC URL.`
+    );
+  }
+  pass(`chainId is ${network.chainId}`);
+
+  // 2. Signer identity: must be the same EOA that deployed on the reference chain.
+  const signers = await ethers.getSigners();
+  if (signers.length === 0) {
+    fail("no signer configured. Is DEPLOYMENT_KEY set in .env?");
+  }
+  const deployer = await signers[0].getAddress();
+  if (config.expectedDeployer && deployer !== config.expectedDeployer) {
+    fail(
+      `signer is ${deployer} but EXPECTED_DEPLOYER_ADDRESS is ${config.expectedDeployer}. ` +
+        "The same deployer EOA is required to reproduce the address."
+    );
+  }
+  pass(`deployer is ${deployer}`);
+
+  // 3. Nonce state: no in-flight transactions, otherwise the mempool could
+  //    consume our target nonces with someone else's payload.
+  const latestNonce = await provider.getTransactionCount(deployer, "latest");
+  const pendingNonce = await provider.getTransactionCount(deployer, "pending");
+  if (latestNonce !== pendingNonce) {
+    fail(
+      `deployer has in-flight transactions (latest nonce ${latestNonce}, pending ` +
+        `${pendingNonce}). Wait for them to confirm or be dropped, then re-run.`
+    );
+  }
+  pass(`nonce is ${latestNonce} with no pending transactions`);
+
+  // 4. Address prediction: implementation at nonce N, proxy at nonce N+1.
+  const predictedImpl = ethers.getCreateAddress({ from: deployer, nonce: latestNonce });
+  const predictedProxy = ethers.getCreateAddress({ from: deployer, nonce: latestNonce + 1 });
+  if (predictedProxy !== config.expectedProxy) {
+    fail(
+      `proxy would deploy to ${predictedProxy} (deployer ${deployer}, nonce ${latestNonce + 1}) ` +
+        `but EXPECTED_PROXY_ADDRESS is ${config.expectedProxy}. The deployer's nonce on this ` +
+        "chain does not line up with the reference deployment. DO NOT send filler transactions " +
+        "without recomputing — every extra transaction moves the prediction."
+    );
+  }
+  if (config.expectedImplementation && predictedImpl !== config.expectedImplementation) {
+    fail(
+      `implementation would deploy to ${predictedImpl} but EXPECTED_IMPLEMENTATION_ADDRESS ` +
+        `is ${config.expectedImplementation}.`
+    );
+  }
+  pass(`predicted implementation ${predictedImpl} (nonce ${latestNonce})`);
+  pass(`predicted proxy ${predictedProxy} matches expected (nonce ${latestNonce + 1})`);
+
+  // 5. Targets must be empty: no contract may already live at either address.
+  for (const [label, addr] of [
+    ["implementation", predictedImpl],
+    ["proxy", predictedProxy],
+  ] as const) {
+    const code = await provider.getCode(addr);
+    if (code !== "0x") {
+      fail(`code already exists at predicted ${label} address ${addr}`);
+    }
+  }
+  pass("no code at either predicted address");
+
+  // 6. OZ manifest must not exist for this chain (would skip the impl tx and
+  //    shift the proxy nonce).
+  checkNoOzManifest(config.expectedChainId);
+  pass("no OpenZeppelin manifest for this chain");
+
+  // 7. Gas estimation for the implementation deployment. This is executed by
+  //    the node against current state, so it catches init-code problems and
+  //    chain-specific gas differences BEFORE anything is broadcast. The proxy
+  //    tx (which runs the initializer) is estimated by ethers right before it
+  //    is sent — a reverting initializer aborts off-chain without consuming
+  //    the proxy nonce.
+  const ContractFactory = await ethers.getContractFactory("Stablecoin");
+  let implGasEstimate: bigint;
+  try {
+    implGasEstimate = await provider.estimateGas({
+      from: deployer,
+      data: ContractFactory.bytecode,
+    });
+  } catch (error) {
+    fail(`implementation deployment gas estimation reverted: ${error}`);
+  }
+  pass(`implementation gas estimate: ${implGasEstimate}`);
+
+  // 8. Initializer arguments must encode cleanly (catches type/arity drift
+  //    between this script and the contract's initialize signature).
+  try {
+    ContractFactory.interface.encodeFunctionData("initialize", [
+      config.tokenName,
+      config.tokenSymbol,
+      config.tokenDecimals,
+      config.adminAddress,
+      config.defaultAdminDelay,
+      config.freezerAddress,
+      config.masterMinterAddress,
+      config.upgraderAddress,
+      config.blacklisterAddress,
+      config.rescuerAddress,
+      config.defaultMintCap,
+    ]);
+  } catch (error) {
+    fail(`initializer arguments failed to encode: ${error}`);
+  }
+  pass("initializer arguments encode cleanly");
+
+  // 9. Metadata parity with the reference deployment: the token being created
+  //    here must have the same name/symbol/decimals as the token already live
+  //    at the expected address on the reference chain. Address parity alone
+  //    is not enough — a typo'd TOKEN_NAME would otherwise deploy a
+  //    different-looking token at the right address.
+  if (config.referenceRpcUrl) {
+    const referenceProvider = new ethers.JsonRpcProvider(config.referenceRpcUrl);
+    try {
+      let referenceChainId: bigint;
+      try {
+        referenceChainId = (await referenceProvider.getNetwork()).chainId;
+      } catch (error) {
+        fail(`could not reach REFERENCE_RPC_URL: ${error}`);
+      }
+      if (referenceChainId === config.expectedChainId) {
+        fail(
+          `REFERENCE_RPC_URL reports chainId ${referenceChainId}, the same as the target ` +
+            "chain. It must point at the chain where the token is ALREADY deployed."
+        );
+      }
+      await verifyReferenceMetadata(config, referenceProvider);
+      pass(`token metadata matches the reference deployment on chain ${referenceChainId}`);
+      await verifyReferenceBytecode(config, referenceProvider);
+      pass("runtime bytecode matches the reference implementation");
+    } finally {
+      referenceProvider.destroy();
+    }
+  } else {
+    console.warn(
+      "  ! no reference RPC available — skipping metadata parity check. Set " +
+        "REFERENCE_RPC_URL (or INFURA_API_KEY for mainnet targets) so " +
+        "name/symbol/decimals are verified against the live token."
+    );
+  }
+
+  // 10. Balance must cover BOTH transactions with buffer. Running out of funds
+  //    after the implementation tx would strand the deployment mid-sequence.
+  const feeData = await provider.getFeeData();
+  const maxFeePerGas = feeData.maxFeePerGas ?? feeData.gasPrice;
+  // Explicit null check: 0n is falsy but is legitimate fee data on
+  // zero-fee networks and must not abort preflight.
+  if (maxFeePerGas === null) {
+    fail("RPC returned no fee data; cannot verify the deployer balance is sufficient");
+  }
+  const totalGas =
+    ((implGasEstimate + PROXY_GAS_UPPER_BOUND) * (100n + config.gasBufferPercent)) / 100n;
+  const requiredWei = totalGas * maxFeePerGas;
+  const balance = await provider.getBalance(deployer);
+  if (balance < requiredWei) {
+    fail(
+      `deployer balance ${ethers.formatEther(balance)} is below the required ` +
+        `~${ethers.formatEther(requiredWei)} (both txs at current max fee ` +
+        `${maxFeePerGas} wei/gas + ${config.gasBufferPercent}% buffer). Fund ${deployer} first.`
+    );
+  }
+  pass(
+    `balance ${ethers.formatEther(balance)} covers estimated ` +
+      `${ethers.formatEther(requiredWei)} for both transactions`
+  );
+
+  console.log(`=== All ${checks.length} preflight checks passed ===\n`);
+  return { deployer };
+}
+
+export async function verifyDeployment(
+  config: DeterministicConfig,
+  proxyAddress: string
+): Promise<void> {
+  console.log("\n=== Post-deploy verification ===");
+  const provider = ethers.provider;
+  const failures: string[] = [];
+  const assert = (condition: boolean, message: string) => {
+    if (condition) {
+      console.log(`  ✓ ${message}`);
+    } else {
+      console.error(`  ✗ ${message}`);
+      failures.push(message);
+    }
+  };
+
+  assert(
+    proxyAddress === config.expectedProxy,
+    `proxy address ${proxyAddress} matches expected ${config.expectedProxy}`
+  );
+
+  const implementationAddress = await upgrades.erc1967.getImplementationAddress(proxyAddress);
+  if (config.expectedImplementation) {
+    assert(
+      ethers.getAddress(implementationAddress) === config.expectedImplementation,
+      `implementation ${implementationAddress} matches expected ${config.expectedImplementation}`
+    );
+  }
+
+  const slotValue = await provider.getStorage(proxyAddress, ERC1967_IMPLEMENTATION_SLOT);
+  assert(
+    ethers.getAddress(ethers.dataSlice(slotValue, 12)) === ethers.getAddress(implementationAddress),
+    "ERC1967 implementation slot points at the implementation"
+  );
+
+  const token = await ethers.getContractAt("Stablecoin", proxyAddress);
+  assert((await token.name()) === config.tokenName, `name() is "${config.tokenName}"`);
+  assert((await token.symbol()) === config.tokenSymbol, `symbol() is "${config.tokenSymbol}"`);
+  assert(
+    Number(await token.decimals()) === config.tokenDecimals,
+    `decimals() is ${config.tokenDecimals}`
+  );
+
+  const roleChecks: [string, string][] = [
+    ["MASTER_MINTER_ROLE", config.masterMinterAddress],
+    ["UPGRADER_ROLE", config.upgraderAddress],
+    ["FREEZER_ROLE", config.freezerAddress],
+    ["BLACKLISTER_ROLE", config.blacklisterAddress],
+    ["RESCUER_ROLE", config.rescuerAddress],
+  ];
+  for (const [roleName, holder] of roleChecks) {
+    const roleHash = await token.getFunction(roleName)();
+    assert(await token.hasRole(roleHash, holder), `${roleName} granted to ${holder}`);
+  }
+  assert(
+    ethers.getAddress(await token.defaultAdmin()) === config.adminAddress,
+    `defaultAdmin() is ${config.adminAddress}`
+  );
+
+  if (failures.length > 0) {
+    throw new Error(
+      `POST-DEPLOY VERIFICATION FAILED (${failures.length} check(s)):\n- ${failures.join("\n- ")}\n` +
+        "The contracts are on-chain; investigate before granting any roles or minting."
+    );
+  }
+  console.log("=== All post-deploy checks passed ===");
+}
+
+export async function runDeterministicDeploy(
+  config: DeterministicConfig
+): Promise<{ proxyAddress: string; implementationAddress: string } | undefined> {
+  console.log(
+    `Deterministic deploy of ${config.tokenName} (${config.tokenSymbol}, ` +
+      `${config.tokenDecimals} decimals) targeting ${config.expectedProxy} ` +
+      `on chain ${config.expectedChainId}`
+  );
+
+  await preflight(config);
+
+  if (config.dryRun) {
+    console.log("DRY_RUN=true — all preflight checks passed; nothing was broadcast.");
+    return undefined;
+  }
+
+  // NOTE: deliberately NO hardcoded gasLimit. With no override, ethers runs
+  // eth_estimateGas for each transaction immediately before broadcasting it.
+  // A transaction that would revert (or exceed the block gas limit) fails the
+  // estimation and aborts OFF-CHAIN — the nonce is never consumed. A
+  // hardcoded limit would skip estimation and turn those same failures into
+  // on-chain reverts that burn the nonce.
+  const ContractFactory = await ethers.getContractFactory("Stablecoin");
+  const instance = await upgrades.deployProxy(
+    ContractFactory,
+    [
+      config.tokenName,
+      config.tokenSymbol,
+      config.tokenDecimals,
+      config.adminAddress,
+      config.defaultAdminDelay,
+      config.freezerAddress,
+      config.masterMinterAddress,
+      config.upgraderAddress,
+      config.blacklisterAddress,
+      config.rescuerAddress,
+      config.defaultMintCap,
+    ],
+    {
+      kind: "uups",
+      // The nonce math REQUIRES two transactions: implementation at nonce N,
+      // proxy at N+1. Without this, the plugin reuses any implementation it
+      // already knows about (manifest or in-memory state) and sends only the
+      // proxy tx — which then lands at nonce N, i.e. the WRONG address.
+      redeployImplementation: "always",
+    }
+  );
+  await instance.waitForDeployment();
+
+  const proxyAddress = ethers.getAddress(await instance.getAddress());
+  const implementationAddress = await upgrades.erc1967.getImplementationAddress(proxyAddress);
+  console.log(`${config.tokenSymbol} Proxy deployed to: ${proxyAddress}`);
+  console.log(`${config.tokenSymbol} Implementation deployed to: ${implementationAddress}`);
+
+  await verifyDeployment(config, proxyAddress);
+
+  return { proxyAddress, implementationAddress: ethers.getAddress(implementationAddress) };
+}
+
+async function main() {
+  const config = loadConfig();
+  const result = await runDeterministicDeploy(config);
+  if (result) {
+    console.log(
+      `\nRemember to archive .openzeppelin/unknown-${config.expectedChainId}.json (or the ` +
+        "named manifest) per-token, and verify the contracts on the block explorer."
+    );
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/test/deploy-deterministic.ts
+++ b/test/deploy-deterministic.ts
@@ -1,0 +1,621 @@
+// Copyright (c) 2026 BitGo, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { expect } from "chai";
+import { ethers, network, upgrades } from "hardhat";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  DeterministicConfig,
+  checkNoOzManifest,
+  loadConfig,
+  preflight,
+  runDeterministicDeploy,
+  verifyReferenceMetadata,
+  verifyReferenceBytecode,
+  stripCborMetadata,
+  defaultReferenceRpcUrl,
+} from "../scripts/deploy-deterministic";
+
+/**
+ * Explicit rejection helper: asserts the promise rejects and that the error
+ * message contains the given substring.
+ */
+async function expectReject(promise: Promise<unknown>, messageSubstring: string): Promise<void> {
+  let error: Error | undefined;
+  try {
+    await promise;
+  } catch (e) {
+    error = e as Error;
+  }
+  expect(error, `expected rejection containing "${messageSubstring}" but promise resolved`).to.not
+    .be.undefined;
+  expect(error!.message).to.contain(messageSubstring);
+}
+
+const HARDHAT_CHAIN_ID = 31337n;
+const DEFAULT_ADMIN_DELAY = 7n * 24n * 60n * 60n;
+const MINT_CAP = 1_000_000n * 10n ** 6n;
+
+describe("deploy-deterministic script", function () {
+  let deployer: SignerWithAddress;
+  let freezer: SignerWithAddress;
+  let masterMinter: SignerWithAddress;
+  let upgrader: SignerWithAddress;
+  let blacklister: SignerWithAddress;
+  let rescuer: SignerWithAddress;
+
+  before(async function () {
+    [deployer, freezer, masterMinter, upgrader, blacklister, rescuer] =
+      await ethers.getSigners();
+  });
+
+  /**
+   * Builds a config whose expected addresses are freshly derived from the
+   * deployer's CURRENT nonce (implementation at nonce N, proxy at N+1), so
+   * the preflight predictions line up regardless of test ordering.
+   */
+  async function buildAlignedConfig(
+    overrides: Partial<DeterministicConfig> = {}
+  ): Promise<DeterministicConfig> {
+    const nonce = await ethers.provider.getTransactionCount(deployer.address, "latest");
+    return {
+      tokenName: "Test SOFI",
+      tokenSymbol: "SOFI",
+      tokenDecimals: 6,
+      defaultMintCap: MINT_CAP,
+      adminAddress: deployer.address,
+      defaultAdminDelay: DEFAULT_ADMIN_DELAY,
+      freezerAddress: freezer.address,
+      masterMinterAddress: masterMinter.address,
+      upgraderAddress: upgrader.address,
+      blacklisterAddress: blacklister.address,
+      rescuerAddress: rescuer.address,
+      expectedChainId: HARDHAT_CHAIN_ID,
+      expectedDeployer: deployer.address,
+      expectedProxy: ethers.getCreateAddress({ from: deployer.address, nonce: nonce + 1 }),
+      expectedImplementation: ethers.getCreateAddress({ from: deployer.address, nonce }),
+      referenceRpcUrl: undefined,
+      allowBytecodeMismatch: false,
+      gasBufferPercent: 25n,
+      dryRun: false,
+      ...overrides,
+    };
+  }
+
+  describe("preflight", function () {
+    it("passes when every expectation lines up", async function () {
+      const config = await buildAlignedConfig();
+      const { deployer: reported } = await preflight(config);
+      expect(reported).to.equal(deployer.address);
+    });
+
+    it("rejects when the RPC chain id does not match EXPECTED_CHAIN_ID", async function () {
+      const config = await buildAlignedConfig({ expectedChainId: 137n });
+      await expectReject(preflight(config), "chainId");
+    });
+
+    it("rejects when the signer is not the expected deployer", async function () {
+      const config = await buildAlignedConfig({ expectedDeployer: freezer.address });
+      await expectReject(preflight(config), "same deployer EOA is required");
+    });
+
+    it("rejects when the nonce does not line up with the expected proxy address", async function () {
+      const nonce = await ethers.provider.getTransactionCount(deployer.address, "latest");
+      // Expectation computed for a nonce five transactions in the future.
+      const config = await buildAlignedConfig({
+        expectedProxy: ethers.getCreateAddress({ from: deployer.address, nonce: nonce + 6 }),
+      });
+      await expectReject(preflight(config), "does not line up");
+    });
+
+    it("rejects when the predicted implementation does not match", async function () {
+      const config = await buildAlignedConfig({
+        expectedImplementation: freezer.address,
+      });
+      await expectReject(preflight(config), "EXPECTED_IMPLEMENTATION_ADDRESS");
+    });
+
+    it("detects that a transaction shifted the nonce since expectations were computed", async function () {
+      const config = await buildAlignedConfig();
+      // Any transaction from the deployer invalidates the prediction.
+      await (await deployer.sendTransaction({ to: freezer.address, value: 1n })).wait();
+      await expectReject(preflight(config), "does not line up");
+    });
+
+    it("rejects when code already exists at the predicted implementation address", async function () {
+      const config = await buildAlignedConfig();
+      await network.provider.send("hardhat_setCode", [
+        config.expectedImplementation,
+        "0x60006000fd",
+      ]);
+      try {
+        await expectReject(preflight(config), "code already exists");
+      } finally {
+        await network.provider.send("hardhat_setCode", [config.expectedImplementation, "0x"]);
+      }
+    });
+
+    it("rejects when the deployer has in-flight (pending) transactions", async function () {
+      const config = await buildAlignedConfig();
+      await network.provider.send("evm_setAutomine", [false]);
+      try {
+        await deployer.sendTransaction({ to: freezer.address, value: 1n });
+        await expectReject(preflight(config), "in-flight");
+      } finally {
+        await network.provider.send("evm_setAutomine", [true]);
+        await network.provider.send("evm_mine");
+      }
+    });
+
+    it("rejects when the deployer balance cannot cover both transactions", async function () {
+      const config = await buildAlignedConfig();
+      const originalBalance = await ethers.provider.getBalance(deployer.address);
+      // 1 wei: far below the cost of either transaction.
+      await network.provider.send("hardhat_setBalance", [deployer.address, "0x1"]);
+      try {
+        // Depending on the node this fails at gas estimation (upfront-cost
+        // validation) or at the explicit balance check — both are preflight
+        // failures that abort before any broadcast.
+        await expectReject(preflight(config), "PREFLIGHT FAILED");
+      } finally {
+        await network.provider.send("hardhat_setBalance", [
+          deployer.address,
+          "0x" + originalBalance.toString(16),
+        ]);
+      }
+    });
+  });
+
+  describe("verifyReferenceMetadata", function () {
+    // A token deployed the normal way stands in for the reference deployment
+    // (e.g. SOFID on Ethereum). The check only reads metadata at
+    // config.expectedProxy on the given provider, so pointing expectedProxy at
+    // this token exercises it without a second chain.
+    let referenceTokenAddress: string;
+
+    before(async function () {
+      const ContractFactory = await ethers.getContractFactory("Stablecoin");
+      const instance = await upgrades.deployProxy(
+        ContractFactory,
+        [
+          "Test SOFI",
+          "SOFI",
+          6,
+          deployer.address,
+          DEFAULT_ADMIN_DELAY,
+          freezer.address,
+          masterMinter.address,
+          upgrader.address,
+          blacklister.address,
+          rescuer.address,
+          MINT_CAP,
+        ],
+        { kind: "uups", redeployImplementation: "always" }
+      );
+      await instance.waitForDeployment();
+      referenceTokenAddress = await instance.getAddress();
+    });
+
+    async function configAgainstReference(
+      overrides: Partial<DeterministicConfig> = {}
+    ): Promise<DeterministicConfig> {
+      const config = await buildAlignedConfig(overrides);
+      return { ...config, expectedProxy: referenceTokenAddress, ...overrides };
+    }
+
+    it("passes when name, symbol, and decimals all match", async function () {
+      const config = await configAgainstReference();
+      await verifyReferenceMetadata(config, ethers.provider);
+    });
+
+    it("rejects a name mismatch", async function () {
+      const config = await configAgainstReference({ tokenName: "Wrong Name" });
+      await expectReject(
+        verifyReferenceMetadata(config, ethers.provider),
+        'name: reference is "Test SOFI" but TOKEN_NAME is "Wrong Name"'
+      );
+    });
+
+    it("rejects a symbol mismatch", async function () {
+      const config = await configAgainstReference({ tokenSymbol: "WRONG" });
+      await expectReject(
+        verifyReferenceMetadata(config, ethers.provider),
+        'symbol: reference is "SOFI" but TOKEN_SYMBOL is "WRONG"'
+      );
+    });
+
+    it("rejects a decimals mismatch", async function () {
+      const config = await configAgainstReference({ tokenDecimals: 18 });
+      await expectReject(
+        verifyReferenceMetadata(config, ethers.provider),
+        "decimals: reference is 6 but TOKEN_DECIMALS is 18"
+      );
+    });
+
+    it("reports every mismatched field at once", async function () {
+      const config = await configAgainstReference({
+        tokenName: "Wrong Name",
+        tokenSymbol: "WRONG",
+        tokenDecimals: 18,
+      });
+      let error: Error | undefined;
+      try {
+        await verifyReferenceMetadata(config, ethers.provider);
+      } catch (e) {
+        error = e as Error;
+      }
+      expect(error).to.not.be.undefined;
+      expect(error!.message).to.contain("name:");
+      expect(error!.message).to.contain("symbol:");
+      expect(error!.message).to.contain("decimals:");
+    });
+
+    it("rejects when no contract exists at the reference address", async function () {
+      const config = await buildAlignedConfig(); // expectedProxy has no code yet
+      await expectReject(
+        verifyReferenceMetadata(config, ethers.provider),
+        "no contract at"
+      );
+    });
+  });
+
+  describe("verifyReferenceBytecode", function () {
+    let referenceProxy: string;
+    let referenceImpl: string;
+
+    before(async function () {
+      const ContractFactory = await ethers.getContractFactory("Stablecoin");
+      const instance = await upgrades.deployProxy(
+        ContractFactory,
+        [
+          "Bytecode Ref",
+          "BREF",
+          6,
+          deployer.address,
+          DEFAULT_ADMIN_DELAY,
+          freezer.address,
+          masterMinter.address,
+          upgrader.address,
+          blacklister.address,
+          rescuer.address,
+          MINT_CAP,
+        ],
+        { kind: "uups", redeployImplementation: "always" }
+      );
+      await instance.waitForDeployment();
+      referenceProxy = await instance.getAddress();
+      referenceImpl = await upgrades.erc1967.getImplementationAddress(referenceProxy);
+    });
+
+    async function configAgainstReference(
+      overrides: Partial<DeterministicConfig> = {}
+    ): Promise<DeterministicConfig> {
+      const config = await buildAlignedConfig();
+      return {
+        ...config,
+        expectedProxy: referenceProxy,
+        expectedImplementation: undefined,
+        ...overrides,
+      };
+    }
+
+    it("passes when the artifact matches the reference implementation byte-for-byte", async function () {
+      const config = await configAgainstReference();
+      await verifyReferenceBytecode(config, ethers.provider);
+    });
+
+    it("cross-checks EXPECTED_IMPLEMENTATION_ADDRESS against the reference proxy's slot", async function () {
+      const config = await configAgainstReference({
+        expectedImplementation: freezer.address,
+      });
+      await expectReject(
+        verifyReferenceBytecode(config, ethers.provider),
+        "may have been upgraded"
+      );
+    });
+
+    it("rejects when the reference implementation runs different code", async function () {
+      // Overwrite the reference implementation's code with a different
+      // contract's bytecode to simulate source/compiler drift.
+      const original = await ethers.provider.getCode(referenceImpl);
+      const validatorArtifact = await ethers.getContractFactory("MockSupplyValidator");
+      const validator = await validatorArtifact.deploy();
+      await validator.waitForDeployment();
+      const otherCode = await ethers.provider.getCode(await validator.getAddress());
+      await network.provider.send("hardhat_setCode", [referenceImpl, otherCode]);
+      try {
+        const config = await configAgainstReference();
+        await expectReject(
+          verifyReferenceBytecode(config, ethers.provider),
+          "does not match the reference implementation"
+        );
+        // ...unless the mismatch is explicitly allowed.
+        const permissive = await configAgainstReference({ allowBytecodeMismatch: true });
+        await verifyReferenceBytecode(permissive, ethers.provider);
+      } finally {
+        await network.provider.send("hardhat_setCode", [referenceImpl, original]);
+      }
+    });
+
+    it("rejects when the reference address is not an ERC1967 proxy", async function () {
+      const config = await configAgainstReference({ expectedProxy: referenceImpl });
+      await expectReject(
+        verifyReferenceBytecode(config, ethers.provider),
+        "no ERC1967"
+      );
+    });
+
+    it("stripCborMetadata removes only a plausible trailer", function () {
+      // 4 data bytes + 2-byte trailer + 2-byte length (0x0002).
+      expect(stripCborMetadata("0xaabbccddeeff0002")).to.equal("0xaabbccdd");
+      // Implausible length (longer than the bytecode) → undefined.
+      expect(stripCborMetadata("0xaabbffff")).to.equal(undefined);
+      expect(stripCborMetadata("0x")).to.equal(undefined);
+    });
+  });
+
+  describe("checkNoOzManifest", function () {
+    const manifestPath = path.join(__dirname, "..", ".openzeppelin", "unknown-31337.json");
+
+    it("throws when a manifest exists for the target chain", function () {
+      fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+      fs.writeFileSync(manifestPath, "{}");
+      try {
+        expect(() => checkNoOzManifest(31337n)).to.throw("manifest");
+      } finally {
+        fs.rmSync(manifestPath, { force: true });
+      }
+    });
+
+    it("passes when no manifest exists for the target chain", function () {
+      expect(fs.existsSync(manifestPath)).to.equal(false);
+      expect(() => checkNoOzManifest(31337n)).to.not.throw();
+    });
+  });
+
+  describe("loadConfig environment validation", function () {
+    const ENV_KEYS = [
+      "TOKEN_NAME",
+      "TOKEN_SYMBOL",
+      "TOKEN_DECIMALS",
+      "DEFAULT_MINT_CAP",
+      "ADMIN_ADDRESS",
+      "DEFAULT_ADMIN_DELAY",
+      "FREEZER_ADDRESS",
+      "MASTER_MINTER_ADDRESS",
+      "UPGRADER_ADDRESS",
+      "BLACKLISTER_ADDRESS",
+      "RESCUER_ADDRESS",
+      "EXPECTED_CHAIN_ID",
+      "EXPECTED_DEPLOYER_ADDRESS",
+      "EXPECTED_PROXY_ADDRESS",
+      "EXPECTED_IMPLEMENTATION_ADDRESS",
+      "REFERENCE_RPC_URL",
+      "INFURA_API_KEY",
+      "GAS_BUFFER_PERCENT",
+      "DRY_RUN",
+      "PROXY_CONTRACT_ADDRESS",
+    ];
+    let savedEnv: Record<string, string | undefined>;
+
+    beforeEach(function () {
+      savedEnv = {};
+      for (const key of ENV_KEYS) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+      process.env.TOKEN_NAME = "Test SOFI";
+      process.env.TOKEN_SYMBOL = "SOFI";
+      process.env.TOKEN_DECIMALS = "6";
+      process.env.DEFAULT_MINT_CAP = MINT_CAP.toString();
+      process.env.ADMIN_ADDRESS = deployer.address;
+      process.env.DEFAULT_ADMIN_DELAY = DEFAULT_ADMIN_DELAY.toString();
+      process.env.FREEZER_ADDRESS = freezer.address;
+      process.env.MASTER_MINTER_ADDRESS = masterMinter.address;
+      process.env.UPGRADER_ADDRESS = upgrader.address;
+      process.env.BLACKLISTER_ADDRESS = blacklister.address;
+      process.env.RESCUER_ADDRESS = rescuer.address;
+      process.env.EXPECTED_CHAIN_ID = "31337";
+      process.env.EXPECTED_DEPLOYER_ADDRESS = deployer.address;
+      process.env.EXPECTED_PROXY_ADDRESS = freezer.address; // any valid address
+    });
+
+    afterEach(function () {
+      for (const key of ENV_KEYS) {
+        if (savedEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = savedEnv[key];
+        }
+      }
+    });
+
+    it("parses a fully specified environment", function () {
+      const config = loadConfig();
+      expect(config.tokenSymbol).to.equal("SOFI");
+      expect(config.tokenDecimals).to.equal(6);
+      expect(config.defaultMintCap).to.equal(MINT_CAP);
+      expect(config.expectedChainId).to.equal(31337n);
+      expect(config.gasBufferPercent).to.equal(25n); // default
+      expect(config.dryRun).to.equal(false);
+    });
+
+    it("rejects when PROXY_CONTRACT_ADDRESS is set (already deployed)", function () {
+      process.env.PROXY_CONTRACT_ADDRESS = freezer.address;
+      expect(() => loadConfig()).to.throw("already deployed");
+    });
+
+    it("rejects a missing required variable", function () {
+      delete process.env.EXPECTED_PROXY_ADDRESS;
+      expect(() => loadConfig()).to.throw("EXPECTED_PROXY_ADDRESS");
+    });
+
+    it("rejects a malformed address", function () {
+      process.env.EXPECTED_PROXY_ADDRESS = "0x1234";
+      expect(() => loadConfig()).to.throw("not a valid EVM address");
+    });
+
+    it("rejects a mixed-case address with a bad checksum", function () {
+      // Valid hex, wrong EIP-55 capitalization.
+      process.env.EXPECTED_PROXY_ADDRESS = "0x0CB6d03B0aC88A463F67B7Ad99f9f3ec4678092e";
+      expect(() => loadConfig()).to.throw("not a valid EVM address");
+    });
+
+    it("rejects the zero address for a role", function () {
+      process.env.FREEZER_ADDRESS = ethers.ZeroAddress;
+      expect(() => loadConfig()).to.throw("zero address");
+    });
+
+    it("rejects a non-numeric chain id", function () {
+      process.env.EXPECTED_CHAIN_ID = "polygon";
+      expect(() => loadConfig()).to.throw("not a valid integer");
+    });
+
+    it("rejects decimals the initializer would revert on (0 and > 18)", function () {
+      process.env.TOKEN_DECIMALS = "19";
+      expect(() => loadConfig()).to.throw("InvalidDecimals");
+      process.env.TOKEN_DECIMALS = "0";
+      expect(() => loadConfig()).to.throw("InvalidDecimals");
+    });
+
+    it("rejects a mint cap below Stablecoin._MIN_LIMIT", function () {
+      process.env.DEFAULT_MINT_CAP = "0";
+      expect(() => loadConfig()).to.throw("LimitTooLow");
+      process.env.DEFAULT_MINT_CAP = "86399"; // one below _MIN_LIMIT
+      expect(() => loadConfig()).to.throw("LimitTooLow");
+      process.env.DEFAULT_MINT_CAP = "86400"; // exactly _MIN_LIMIT is valid
+      expect(loadConfig().defaultMintCap).to.equal(86400n);
+    });
+
+    it("rejects a zero admin delay (initializer InvalidDelay)", function () {
+      process.env.DEFAULT_ADMIN_DELAY = "0";
+      expect(() => loadConfig()).to.throw("InvalidDelay");
+    });
+
+    it("parses REFERENCE_RPC_URL, falling back to a per-target default when blank", function () {
+      // Explicit value always wins.
+      process.env.REFERENCE_RPC_URL = "https://example.com/rpc";
+      expect(loadConfig().referenceRpcUrl).to.equal("https://example.com/rpc");
+
+      // Blank + unknown target chain (31337): no default available.
+      process.env.REFERENCE_RPC_URL = "   ";
+      expect(loadConfig().referenceRpcUrl).to.equal(undefined);
+
+      // Blank + mainnet target: defaults to Ethereum mainnet via Infura.
+      delete process.env.REFERENCE_RPC_URL;
+      process.env.EXPECTED_CHAIN_ID = "137";
+      process.env.INFURA_API_KEY = "testkey";
+      expect(loadConfig().referenceRpcUrl).to.equal("https://mainnet.infura.io/v3/testkey");
+
+      // Blank + testnet target: defaults to Hoodi.
+      process.env.EXPECTED_CHAIN_ID = "80002";
+      expect(loadConfig().referenceRpcUrl).to.equal("https://rpc.hoodi.ethpandaops.io");
+    });
+
+    it("defaultReferenceRpcUrl maps targets to reference chains", function () {
+      const savedInfura = process.env.INFURA_API_KEY;
+      try {
+        process.env.INFURA_API_KEY = "k";
+        // Mainnet targets -> Ethereum mainnet.
+        for (const id of [137n, 143n, 56n]) {
+          expect(defaultReferenceRpcUrl(id)).to.equal("https://mainnet.infura.io/v3/k");
+        }
+        // Mainnet target without an Infura key -> no default.
+        delete process.env.INFURA_API_KEY;
+        expect(defaultReferenceRpcUrl(137n)).to.equal(undefined);
+        // Testnet targets -> Hoodi.
+        for (const id of [80002n, 10143n]) {
+          expect(defaultReferenceRpcUrl(id)).to.equal("https://rpc.hoodi.ethpandaops.io");
+        }
+        // Unknown target -> no default.
+        expect(defaultReferenceRpcUrl(31337n)).to.equal(undefined);
+      } finally {
+        if (savedInfura === undefined) delete process.env.INFURA_API_KEY;
+        else process.env.INFURA_API_KEY = savedInfura;
+      }
+    });
+
+    it("honors DRY_RUN and GAS_BUFFER_PERCENT", function () {
+      process.env.DRY_RUN = "true";
+      process.env.GAS_BUFFER_PERCENT = "50";
+      const config = loadConfig();
+      expect(config.dryRun).to.equal(true);
+      expect(config.gasBufferPercent).to.equal(50n);
+    });
+  });
+
+  describe("end-to-end deployment", function () {
+    it("dry run passes preflight and broadcasts nothing", async function () {
+      const config = await buildAlignedConfig({ dryRun: true });
+      const nonceBefore = await ethers.provider.getTransactionCount(deployer.address, "latest");
+      const result = await runDeterministicDeploy(config);
+      expect(result).to.equal(undefined);
+      const nonceAfter = await ethers.provider.getTransactionCount(deployer.address, "latest");
+      expect(nonceAfter).to.equal(nonceBefore, "dry run must not consume a nonce");
+    });
+
+    it("aborts before broadcasting anything when the expected proxy is wrong", async function () {
+      const nonce = await ethers.provider.getTransactionCount(deployer.address, "latest");
+      const config = await buildAlignedConfig({
+        expectedProxy: ethers.getCreateAddress({ from: deployer.address, nonce: nonce + 6 }),
+      });
+      const nonceBefore = await ethers.provider.getTransactionCount(deployer.address, "latest");
+      await expectReject(runDeterministicDeploy(config), "does not line up");
+      const nonceAfter = await ethers.provider.getTransactionCount(deployer.address, "latest");
+      expect(nonceAfter).to.equal(nonceBefore, "failed preflight must not consume a nonce");
+    });
+
+    it("deploys implementation and proxy at the predicted addresses and passes all post-deploy checks", async function () {
+      this.timeout(120000);
+      const config = await buildAlignedConfig();
+      const result = await runDeterministicDeploy(config);
+
+      expect(result).to.not.equal(undefined);
+      expect(result!.proxyAddress).to.equal(config.expectedProxy);
+      expect(result!.implementationAddress).to.equal(config.expectedImplementation);
+
+      // Independent verification against the chain (not just the script's output).
+      const token = await ethers.getContractAt("Stablecoin", result!.proxyAddress);
+      expect(await token.name()).to.equal(config.tokenName);
+      expect(await token.symbol()).to.equal(config.tokenSymbol);
+      expect(Number(await token.decimals())).to.equal(config.tokenDecimals);
+      expect(await token.defaultAdmin()).to.equal(config.adminAddress);
+      expect(await token.hasRole(await token.MASTER_MINTER_ROLE(), masterMinter.address)).to.equal(
+        true
+      );
+      expect(await token.hasRole(await token.UPGRADER_ROLE(), upgrader.address)).to.equal(true);
+      expect(await token.hasRole(await token.FREEZER_ROLE(), freezer.address)).to.equal(true);
+      expect(await token.hasRole(await token.BLACKLISTER_ROLE(), blacklister.address)).to.equal(
+        true
+      );
+      expect(await token.hasRole(await token.RESCUER_ROLE(), rescuer.address)).to.equal(true);
+
+      const implCode = await ethers.provider.getCode(result!.implementationAddress);
+      expect(implCode).to.not.equal("0x");
+    });
+
+    it("rejects a rerun with stale expectations without consuming a nonce", async function () {
+      // The previous test deployed the implementation and proxy, advancing
+      // the nonce. Rerunning with those now-stale expected addresses must be
+      // rejected outright — and the rejection must not broadcast anything.
+      const nonce = await ethers.provider.getTransactionCount(deployer.address, "latest");
+      const staleConfig = await buildAlignedConfig({
+        expectedImplementation: ethers.getCreateAddress({
+          from: deployer.address,
+          nonce: nonce - 2,
+        }),
+        expectedProxy: ethers.getCreateAddress({ from: deployer.address, nonce: nonce - 1 }),
+      });
+      await expectReject(runDeterministicDeploy(staleConfig), "does not line up");
+      const nonceAfter = await ethers.provider.getTransactionCount(deployer.address, "latest");
+      expect(nonceAfter).to.equal(nonce, "stale-config rejection must not consume a nonce");
+
+      // A freshly aligned config for the same token still preflights cleanly.
+      const freshConfig = await buildAlignedConfig();
+      const result = await runDeterministicDeploy({ ...freshConfig, dryRun: true });
+      expect(result).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Add polygon (137) and monad (143) networks with explorer config, a deploy-deterministic.ts script whose preflight checks abort before any broadcast that could burn a nonce (chainId/deployer/nonce verification, CREATE address prediction, manifest guard, gas estimation instead of a hardcoded gasLimit, balance check, redeployImplementation "always"), and a 25-test suite covering preflight failures and e2e deployment.

Ticket: SCAAS-10712