### PR TITLE
chore: update repo name references to evm-stablecoin-contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# Stablecoin EVM - Claude Code Configuration
+# EVM Stablecoin Contracts - Claude Code Configuration
 
 ## Project Overview
 
-Stablecoin EVM is a generic stablecoin smart contract system using the UUPS upgradeable proxy pattern. A single reusable `Stablecoin` contract can be deployed multiple times with different initialization parameters (name, symbol, decimals, mint cap, role addresses) to create independent tokens — for example, USD-, EUR-, or GBP-pegged stablecoins.
+EVM Stablecoin Contracts (`evm-stablecoin-contracts`) is a generic stablecoin smart contract system using the UUPS upgradeable proxy pattern. A single reusable `Stablecoin` contract can be deployed multiple times with different initialization parameters (name, symbol, decimals, mint cap, role addresses) to create independent tokens — for example, USD-, EUR-, or GBP-pegged stablecoins.
 
 ## Tech Stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing to stablecoin-evm
+# Contributing to evm-stablecoin-contracts
 
 Thank you for your interest in contributing to this project! This document provides guidelines for contributing.
 
 ## Getting Started
 
 1. Fork the repository
-2. Clone your fork: `git clone https://github.com/<your-username>/stablecoin-evm.git`
+2. Clone your fork: `git clone https://github.com/<your-username>/evm-stablecoin-contracts.git`
 3. Install dependencies: `npm install`
 4. Create a branch: `git checkout -b feature/your-feature-name`
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,12 +1,12 @@
 # Governance
 
-This document describes the governance model for the `stablecoin-evm` project: the
+This document describes the governance model for the `evm-stablecoin-contracts` project: the
 roles participants can hold, how decisions are made, and how the community
 participates.
 
 ## Overview
 
-`stablecoin-evm` is an open source project maintained by BitGo. BitGo retains
+`evm-stablecoin-contracts` is an open source project maintained by BitGo. BitGo retains
 final decision-making authority over the project's direction, releases, and
 acceptance of contributions. The project follows a **maintainer (BDFL-style)
 governance model** with a designated set of maintainers from BitGo's Stablecoins

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stablecoin EVM Contracts
+# EVM Stablecoin Contracts
 
 A generic, EVM-compatible stablecoin smart contract system using the UUPS upgradeable proxy pattern. A single reusable contract can be deployed multiple times with different initialization parameters to create independent stablecoins.
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,9 +3,9 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: stablecoin-evm
+  name: evm-stablecoin-contracts
   annotations:
-    github.com/project-slug: BitGo/stablecoin-evm
+    github.com/project-slug: BitGo/evm-stablecoin-contracts
 spec:
   # The primary purpose of this component. If this repo serves multiple purposes
   # (e.g. both a deployable service and a published library), set this to whichever

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "stablecoin-evm",
+  "name": "evm-stablecoin-contracts",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "stablecoin-evm",
+      "name": "evm-stablecoin-contracts",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stablecoin-evm",
+  "name": "evm-stablecoin-contracts",
   "version": "1.0.0",
   "description": "Generic stablecoin smart contract system using UUPS upgradeable proxy pattern",
   "main": "index.js",
@@ -12,12 +12,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/BitGo/stablecoin-evm.git"
+    "url": "https://github.com/BitGo/evm-stablecoin-contracts.git"
   },
   "bugs": {
-    "url": "https://github.com/BitGo/stablecoin-evm/issues"
+    "url": "https://github.com/BitGo/evm-stablecoin-contracts/issues"
   },
-  "homepage": "https://github.com/BitGo/stablecoin-evm#readme",
+  "homepage": "https://github.com/BitGo/evm-stablecoin-contracts#readme",
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.0",
     "@openzeppelin/contracts-upgradeable": "^5.0.0",


### PR DESCRIPTION
## Why

The repo was renamed `stablecoin-evm` → `evm-stablecoin-contracts` to avoid a naming conflict with an existing public project of the same name, per the open-source release review. Infra change: BitGo/infra#16539 (applied).

## What

- `package.json` / `package-lock.json` — package name and repository/bugs/homepage URLs
- `catalog-info.yaml` — Backstage component name and project slug
- `README.md`, `GOVERNANCE.md`, `CONTRIBUTING.md`, `CLAUDE.md` — titles and project references

No contract or test changes.

Linear: [SCAAS-10926](https://linear.app/bitgo/issue/SCAAS-10926)